### PR TITLE
adding the featured narratives as a list (for now)

### DIFF
--- a/functional-site/views/ws/featured.html
+++ b/functional-site/views/ws/featured.html
@@ -1,20 +1,71 @@
 <div id="newsfeed_inner" >
     <div id="feed_section" >
         <div style="overflow: auto;"><h2 class="small pull-left">Featured Narratives </h2><span class="glyphicon glyphicon-question-sign pull-left" style="color: #0088CC; font-size: 16px; padding-left: 5px"
-        popover="Featured Narratives are exemplar narratives that demonstrate the types of analyses you can build in the user interface. Click on the title to view the narrative or click the copy narrative link to copy the narrative and its datasets to your home workspace." 
+        popover="Featured Narratives are exemplar narratives that demonstrate the types of analyses you can build in the user interface. Click on the title to view a narrative." 
         popover-trigger="mouseenter"
         popover-placement="bottom" 
             ></span></div>
         <div class="newsfeed_section">
                 
-           <!-- <div newsfeed class="newsfeed_section">
+         <!--   <div newsfeed class="newsfeed_section">
             </div>
             -->
-            <p><b>New Featured Narratives Are Coming Soon!</b></p>
+            <p>
+                If you'd like to run these Narratives yourself, or even change them, you can clone them into your workspace.
+Click on a Narrative name to open a Narrative in a new tab, and then follow the <a href="http://kbase.us/get-started/narrative-quick-start/#copynarrative">instructions here</a> to clone it.
+            </p>
+            <BR>
+
+
+            <h4>Microbial Genome Analysis: Assembly, Annotation, Comparative Genomics, Metabolic Modeling, and Regulatory Modeling</h4>
+            <ul>
+                <li>
+                    <a href="/narrative/ws.2177.obj.8">Genome assembly and annotation</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2177.obj.7">Comparative genomics</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2177.obj.9">Metabolic model reconstruction and analysis</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2177.obj.11">Phenotype simulation and regulatory modeling</a>
+                </li>
+            </ul>
+<BR>
+            <h4>Plants</h4>
+            <ul>
+                <li>
+                    <a href="/narrative/ws.2193.obj.86">Discovery of Candidate Genes Regulating Lignin Content in Poplar Using Genome-Wide Association Studies and Network Analysis</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2187.obj.245">Sorghum RNA-Seq Analysis in Response to ABA and Osmotic Stress in Roots and Shoots</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2194.obj.1">Coexpression and Network Analysis</a>
+                </li>
+            </ul>
+            <BR>
+            <h4>Communities</h4>
+            <ul>
+                <li>
+                    <a href="/narrative/ws.2171.obj.3">Metagenome Shotgun to Functional BIOM Profile</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2171.obj.4">Metagenome Shotgun to Taxonomic BIOM Profile</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2171.obj.2">Metagenome Shotgun 16Ssubset to Taxonomic BIOM</a>
+                </li>
+                <li>
+                    <a href="/narrative/ws.2171.obj.1">Metagenome Shotgun 16Ssubset PICRUST Function</a>
+                </li>
+            </ul>
+         <!--   <p><b>New Featured Narratives Are Coming Soon!</b></p>
 <p>KBase is currently undergoing a major update. New featured narratives are being developed and will appear here soon.</p>
 <p>In the meantime, you can explore public narratives and narratives that have been shared with you via the tabs to the left. (Tip: Sign in to view the "Mine" and "Shared With Me" tabs.)</p>
 You can also build your own narrative! The <a href="http://kbase.us/for-users/narrative-quick-start/">Narrative Quick Start</a> guide, which describes how to create and run narratives, can be found <a href="http://kbase.us/for-users/narrative-quick-start/">here</a>.
-
+-->
         </div>	
     </div>
 </div>

--- a/functional-site/views/ws/narratives.html
+++ b/functional-site/views/ws/narratives.html
@@ -18,7 +18,7 @@
 
             <div class="narrative-filters">
                 <a ui-sref="narratives.featured" ng-class="{ active: $state.includes('narratives.featured')}" class="select-nar">
-                    <div class="badge">3</div> 
+                    <div class="badge">11</div> 
                     <span> <b>Featured Narratives</b></span>
                     <span class="glyphicon glyphicon-chevron-right pull-right"></span>
                 </a> 


### PR DESCRIPTION
Adding the featured narratives as a list (hard coded in the html for now). If we continue this as a list (that is up in the air), we'd want to think about the appropriate storage type for this. Maybe this can be a json file that lives on Concrete 5
