### PR TITLE
Fix URL constructed for recent narratives list.

### DIFF
--- a/functional-site/views/ws/narratives.html
+++ b/functional-site/views/ws/narratives.html
@@ -47,7 +47,7 @@
                 <div recentnarratives>
                     <ul class="recent-nars" ng-repeat="nar in narratives | orderBy:'timestamp':true | limitTo:5">
                         <li>
-                            <a href="{{nar_url}}/narrative/ws.{{nar.wsid}}.obj.{{nar.id}}" target="_blank" class="ellipsis">{{nar.name}}</a><br>
+                            <a href="{{nar_url}}/ws.{{nar.wsid}}.obj.{{nar.id}}" target="_blank" class="ellipsis">{{nar.name}}</a><br>
                             <div class="recent-nar-time text-muted">
                                 <i>{{nar.owner}}</i> <span class="pull-right"><i>{{nar.nealtime}}</i></span>
                             </div>


### PR DESCRIPTION
This removes the duplicate narrative from the URLs in the recent narratives list (right now the URLs look like https://narrative.kbase.us/narrative/narrative/ws.NNN.obj.XXX).