### PR TITLE
User page

### DIFF
--- a/functional-site/index.html
+++ b/functional-site/index.html
@@ -266,7 +266,7 @@
         <!-- <script src="../src/widgets/social/kbaseUserRecentActivity.js"></script> -->
         <script src="../src/widgets/social/kbaseUserCollaboratorNetwork.js"></script>
         <script src="../src/widgets/social/kbaseUserProjectMembership.js"></script>
-        <script src="../src/widgets/social/kbaseUserPopularNarratives.js"></script>
+        <!-- <script src="../src/widgets/social/kbaseUserPopularNarratives.js"></script> -->
         <script src="../src/widgets/social/kbaseUserTopApps.js"></script>
         <script src="../src/widgets/social/kbaseUserResourceUsage.js"></script>
         

--- a/functional-site/js/directives/social.js
+++ b/functional-site/js/directives/social.js
@@ -166,26 +166,27 @@ angular.module('social-directives')
             }
         };
     })
-    .directive('socialuserhistoryx', function($rootScope) {
+    .directive('socialuserpopularnarratives', function($rootScope) {
         return {
             link: function(scope, ele, attrs) {
-                var userId = scope.params.userid;
-
-                // setup panel
-                var p = $(ele).kbasePanel({
-                    title: "Recent Activity"
-                }) /* ,rightLabel: "ws", subText: scope.userid}); */
-                p.loading();
-                $(p.body()).KBaseUserRecentActivity({
-                    // userInfo: data[0],
-                    // wsUserInfoUrl: peopleWsUrl,
-                    // wsUserInfoRef: userId + ":userinfo/info",
-                    userId: userId,
-                    kbCache: scope.params.kbCache
-                });
+              
+              require(['kbaseuserpopularnarratives'], function(Widget) {
+                try {
+                  var widget = Object.create(Widget);
+                  widget.init({
+                      container: $(ele),
+                      userId: scope.params.userid,
+                      authToken: scope.params.kbCache.token,
+                      workspaceURL: scope.params.kbCache.ws_url
+                  }).go();
+                } catch (ex) {
+                  $(ele).html('Error: ' + ex);
+                }
+              });
             }
         };
     })
+    
     .directive('socialusercollaborators', function($rootScope) {
         return {
             link: function(scope, ele, attrs) {
@@ -270,52 +271,7 @@ angular.module('social-directives')
             }
         };
     })
-
-.directive('socialuserpopularnarratives', function($rootScope) {
-    return {
-        link: function(scope, ele, attrs) {
-            var userId = scope.params.userid;
-
-            // setup panel
-            var p = $(ele).kbasePanel({
-                title: "Popular Narratives"
-            }) /* ,rightLabel: "ws", subText: scope.userid}); */
-            p.loading();
-
-            // create ws client (because we need to go to the dev workspace)
-            var peopleWsUrl = "http://dev04.berkeley.kbase.us:7058";
-            var ws;
-            if (scope.params.kbCache.token) {
-                ws = new Workspace(peopleWsUrl, {
-                    token: scope.params.kbCache.token
-                });
-            } else {
-                ws = new Workspace(peopleWsUrl);
-            }
-
-            var objectIds = [{
-                ref: userId + ":userinfo/info"
-            }];
-            ws.get_objects(objectIds,
-                function(data) {
-                    // create the widget if we found the data
-                    $(p.body()).KBaseUserPopularNarratives({
-                        userInfo: data[0],
-                        wsUserInfoUrl: peopleWsUrl,
-                        wsUserInfoRef: userId + ":userinfo/info",
-                        kbCache: scope.params.kbCache
-                    });
-                },
-                function(err) {
-                    // if we get an error, then no workspace or no profile exists (or is readable by this user...) and we just exit
-                    $(p.body()).append("Not visible for user <i>" + userId + "</i>.");
-                });
-        }
-    };
-})
-
-
-.directive('socialusertopapps', function($rootScope) {
+    .directive('socialusertopapps', function($rootScope) {
     return {
         link: function(scope, ele, attrs) {
             var userId = scope.params.userid;

--- a/functional-site/js/require-config.js
+++ b/functional-site/js/require-config.js
@@ -23,7 +23,8 @@ require.config({
       // userProfileServiceClient: '/functional-site/assets/js/kbclient/user_profile_Client.js',
       kbasesocialwidget: '/src/widgets/social/kbaseSocialWidget',
       kbaseuserprofilewidget: '/src/widgets/social/kbaseUserProfile',
-      kbaseuserrecentactivity: '/src/widgets/social/kbaseUserRecentActivity'
+      kbaseuserrecentactivity: '/src/widgets/social/kbaseUserRecentActivity',
+      kbaseuserpopularnarratives: '/src/widgets/social/kbaseUserPopularNarratives'
     },
    shim: { 
     'kbaseuserprofileserviceclient': {

--- a/src/widgets/social/RecentActivity/templates/error.html
+++ b/src/widgets/social/RecentActivity/templates/error.html
@@ -1,6 +1,6 @@
-<p>{{title}}</p>
+<p>{{error.title}}</p>
 
-{{message | kbmarkup}}
+{{error.message | kbmarkup}}
 
 <!--
 <hr>

--- a/src/widgets/social/RecentActivity/templates/layout.html
+++ b/src/widgets/social/RecentActivity/templates/layout.html
@@ -1,6 +1,7 @@
 <div class="panel panel-default">
     <div class="panel-heading"><span class="panel-title" data-placeholder="title">{{env.widgetTitle}}</span></div>
     <div class="panel-body">
+    	<div data-placeholder="alert"></div>
         <div data-placeholder="content"></div>
     </div>
 </div>

--- a/src/widgets/social/RecentActivity/templates/recent_activity.html
+++ b/src/widgets/social/RecentActivity/templates/recent_activity.html
@@ -7,7 +7,7 @@
 		{# <td>{{activity.type | typeIcon }}</td> 
 		<td><b>{{activity.type}}</b> - {{activity.name}}<br><i>modified on {{activity.date | dateFormat }}</i></td>
 		#}
-		<td><a target="_blank" href="/narrative/{{activity.obj_id}}">{{activity.nice_name}}</a><br><i>modified on {{activity.date | dateFormat }}
+		<td><a target="_blank" href="/narrative/{{activity.obj_id}}">{{activity.nice_name}}</a><br><i>modified on {{activity.save_date | dateFormat }}
 		{% if activity.description %}<p>{{activity.description}}</p>{% endif %}</td>
 	</tr>
 	

--- a/src/widgets/social/RecentActivity/templates/recent_activity.html
+++ b/src/widgets/social/RecentActivity/templates/recent_activity.html
@@ -4,10 +4,11 @@
 
 {% for activity in data.recentActivity %}
 	<tr>
-		<!-- <td>{{activity.type | typeIcon }}</td> 
+		{# <td>{{activity.type | typeIcon }}</td> 
 		<td><b>{{activity.type}}</b> - {{activity.name}}<br><i>modified on {{activity.date | dateFormat }}</i></td>
-		-->
-		<td><a target="_blank" href="/narrative/{{activity.obj_id}}">{{activity.ws_object.data.metadata.name}}</a><br><i>modified on {{activity.date | dateFormat }}</td>
+		#}
+		<td><a target="_blank" href="/narrative/{{activity.obj_id}}">{{activity.nice_name}}</a><br><i>modified on {{activity.date | dateFormat }}
+		{% if activity.description %}<p>{{activity.description}}</p>{% endif %}</td>
 	</tr>
 	
 {% endfor %}

--- a/src/widgets/social/UserPopularNarratives/templates/error.html
+++ b/src/widgets/social/UserPopularNarratives/templates/error.html
@@ -1,0 +1,14 @@
+<p>{{error.title}}</p>
+
+{{error.message | kbmarkup}}
+
+<!--
+<hr>
+<p>Response Text: {{responseText}}</p>
+<p>Error Type: {{status}}</p>
+<p>Error: {{error}}</p>
+<hr>
+<h3>Technical</h3>
+<p>Status: {{jqxhr.status}}</p>
+<p>Status Text: {{jqxhr.statusText}}</p>
+-->

--- a/src/widgets/social/UserPopularNarratives/templates/layout.html
+++ b/src/widgets/social/UserPopularNarratives/templates/layout.html
@@ -1,0 +1,7 @@
+<div class="panel panel-default">
+    <div class="panel-heading"><span class="panel-title" data-placeholder="title">{{env.widgetTitle}}</span></div>
+    <div class="panel-body">
+    	<div data-placeholder="alert"></div>
+        <div data-placeholder="content"></div>
+    </div>
+</div>

--- a/src/widgets/social/UserPopularNarratives/templates/popular_narratives.html
+++ b/src/widgets/social/UserPopularNarratives/templates/popular_narratives.html
@@ -1,0 +1,27 @@
+<table cellpadding="0" cellspacing="0" border="0" class="table table-bordered table-striped">
+
+{% if data.popularNarratives | length > 0 %}
+
+{% for narrative in data.popularNarratives %}
+	<tr>
+		{# <td>{{narrative.type | typeIcon }}</td> 
+		<td><b>{{narrative.type}}</b> - {{narrative.name}}<br><i>modified on {{narrative.save_date | dateFormat }}</i></td>
+		#}
+		<td><a target="_blank" href="/narrative/{{narrative.obj_id}}">{{narrative.nice_name}}</a>
+		<br>
+		<i>modified on {{narrative.save_date | dateFormat }}
+		{% if narrative.description %}<p>{{narrative.description}}</p>{% endif %}</td>
+		<td valign="top" align="right">
+		 {{narrative.version}} saves
+		</td>
+	</tr>
+	
+{% endfor %}
+
+{% else %}
+
+Sorry, no popular narratives.
+
+{% endif %}
+
+</table>

--- a/src/widgets/social/UserPopularNarratives/templates/unauthorized.html
+++ b/src/widgets/social/UserPopularNarratives/templates/unauthorized.html
@@ -1,0 +1,4 @@
+
+<p>You are not authorized to view a user profile.</p>
+
+           

--- a/src/widgets/social/UserPopularNarratives/templates/user.html
+++ b/src/widgets/social/UserPopularNarratives/templates/user.html
@@ -1,0 +1,4 @@
+
+<p>The requested user, {{ env.userId }}, was not found in KBase.</p>
+
+           

--- a/src/widgets/social/kbaseSocialWidget.js
+++ b/src/widgets/social/kbaseSocialWidget.js
@@ -28,6 +28,10 @@ define(['nunjucks', 'jquery'], function (nunjucks, $) {
                   throw 'Widget title is required';
                 }
                 this.widgetTitle = cfg.title;
+                
+
+
+                this.messages = [];
 
 
                 // TODO: FIX THIS!!!
@@ -64,6 +68,12 @@ define(['nunjucks', 'jquery'], function (nunjucks, $) {
                 this.templates = {};
                 this.templates.env = new nunjucks.Environment(new nunjucks.WebLoader('/src/widgets/social/'+this.widgetName+'/templates'), {
                     'autoescape': false
+                });
+                this.templates.env.addFilter('kbmarkup', function(s) {
+                  if (s) {
+                    s = s.replace(/\n/g, '<br>');
+                  }
+                  return s;
                 });
                 // This is the cache of templates.
                 this.templates.cache = {};
@@ -104,10 +114,12 @@ define(['nunjucks', 'jquery'], function (nunjucks, $) {
                     	this.render()
                     }.bind(this),
                     error: function (err) {
-                      if (typeof error === 'string') {
+                      console.log('ERROR');
+                      console.log(err);
+                      if (typeof err === 'string') {
                         err = {
                           title: 'Error',
-                          message: 'err'
+                          message: err
                         }
                       }
                       this.renderErrorView(err);
@@ -236,6 +248,7 @@ define(['nunjucks', 'jquery'], function (nunjucks, $) {
                 this.container.html(this.getTemplate('layout').render(this.context));
                 this.places = {
                 	title: this.container.find('[data-placeholder="title"]'),
+                  alert: this.container.find('[data-placeholder="alert"]'),
                 	content: this.container.find('[data-placeholder="content"]')
                 };
             }
@@ -248,6 +261,73 @@ define(['nunjucks', 'jquery'], function (nunjucks, $) {
         renderWaitingView: {
             value: function () {
                 this.places.content.html('<img src="assets/img/ajax-loader.gif"></img>');
+            }
+        },
+        
+        renderMessages: {
+            value: function () {
+                if (this.places.alert) {
+                    this.places.alert.empty();
+                    for (var i=0; i<this.messages.length; i++) {
+                        var message = this.messages[i];
+                        var alertClass = 'default';
+                        switch (message.type) {
+                            case 'success': alertClass = 'dismissable';break;
+                            case 'warning': alertClass = 'warn';break;
+                            case 'error': alertClass = 'danger'; break; 
+                        }
+                        this.places.alert.append(
+                        '<div class="alert alert-success alert-'+alertClass+'" role="alert">' +
+                        '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>' +
+                        '<strong>' + message.title + '</strong> ' + message.message + '</div>');
+                    }
+                }
+            }
+        },
+
+        clearMessages: {
+            value: function() {
+                this.messages = [];
+                this.renderMessages();
+            }
+        },
+
+        addSuccessMessage: {
+            value: function(title, message) {
+              if (message === undefined) {
+                message = title;
+                title = '';
+              }
+                this.messages.push({
+                    type: 'success', title: title, message: message
+                });
+                this.renderMessages();
+            }
+        }, 
+        
+        addWarningMessage: {
+            value: function(title, message) {
+              if (message === undefined) {
+                message = title;
+                title = '';
+              }
+                this.messages.push({
+                    type: 'warning', title: title, message: message
+                });
+                this.renderMessages();
+            }
+        },
+
+        addErrorMessage: {
+            value: function(title, message) {
+              if (message === undefined) {
+                message = title;
+                title = '';
+              }
+                this.messages.push({
+                    type: 'error', title: title, message: message
+                });
+                this.renderMessages();
             }
         }
 

--- a/src/widgets/social/kbaseUserPopularNarratives.js
+++ b/src/widgets/social/kbaseUserPopularNarratives.js
@@ -1,167 +1,204 @@
-(function( $, undefined ) {
-    $.KBWidget({
-        name: "KBaseUserPopularNarratives",
-        parent: "kbaseAuthenticatedWidget",
-        version: "1.0.0",
-        
-        userNameFetchUrl:"https://kbase.us/services/genome_comparison/users?usernames=",
-	
-	
-        options: {
-            userInfo:null,
-	    wsUserInfoUrl:"https://dev04.berkeley.kbase.us:7058",
-	    wsUserInfoRef:"",
-            kbCache:{},
-        },
-    
-	wsUserName:"",
-	wsUserInfoClient:null,
-	loggedIn:false,
-	loggedInUserId:null,
-	userInfoData:null,
-	isMe:false,
-	
-	alertPanel:null,
-	
-        init: function(options) {
-            this._super(options);
-            var self = this;
-	    /* we don't need the user profile data for now...
-	     if (options.wsUserInfoUrl) {
-		if (options.kbCache.token) {
-		    self.wsUserInfoClient = new Workspace(options.wsUserInfoUrl, {token: self.options.kbCache.token});
-		} else {
-		    self.wsUserInfoClient = new Workspace(options.wsUserInfoUrl);
-		}
-            }
-	    */
-	    if (self.options.kbCache.ws_url) {
-                self.wsUrl = self.options.kbCache.ws_url;
-            }
-            if (self.options.kbCache.token) {
-                self.ws = new Workspace(self.wsUrl, {token: self.options.kbCache.token});
-		self.loggedIn = true;
-		self.loggedInUserId = $('<div></div>').kbaseLogin().get_kbase_cookie('user_id');
-            } else {
-                self.ws = new Workspace(self.wsUrl);
-            }
-	    
-	    if (options.userInfo) {
-		self.userInfoData = options.userInfo['data'];
-		self.wsUserName = self.userInfoData['basic_personal_info']['user_name'];
-		if (self.wsUserName===self.loggedInUserId) {
-		    self.isMe = true;
-		}
-	    }
-	    // setup the alert panel
-            self.alertPanel = $("<div></div>");
-	    self.$elem.append(self.alertPanel);
-            self.$mainPanel = $("<div></div>").css("overflow","auto").css("height","300px");
-	    self.$elem.append(self.$mainPanel);
-	    
-	    self.getRecentActivity();
-	    self.render();
-	    
-	    return this;
-	},
-    
-	popularNarratives:null,
-    
-	getRecentActivity : function () {
-	    var self = this;
-	    self.ws.list_workspace_info({},
-		function(data) {
-		    var wsids = [];
-		    for(var k=0; k<data.length; k++) {
-			//tuple<ws_id id, ws_name workspace, username owner, timestamp moddate,
-			//int object, permission user_permission, permission globalread,
-			//lock_status lockstat, usermeta metadata> workspace_info
-			if (data[k][2]===self.wsUserName) {
-			    //for now, only include workspaces owned by this user
-			    wsids.push(data[k][0]);
-			}
-		    }
-		    var params = {savedby:[self.wsUserName], type:"KBaseNarrative.Narrative",ids:wsids,includeMetadata:1};
-		    self.ws.list_objects(params,
-			function(data) {
-			    self.popularNarratives=[];
-			    for(var k=0; k<data.length; k++) {
-				//<obj_id objid, obj_name name, type_string type,
-				//timestamp save_date, int version, username saved_by,
-				//ws_id wsid, ws_name workspace, string chsum, int size, usermeta meta>
-				self.popularNarratives.push({
-				    name:data[k][10]['name'],
-				    ws:data[k][7],
-				    size:data[k][9],
-				    version: data[k][4],
-				    date:data[k][3]
-				});
-			    }
-				    
-			    self.popularNarratives.sort(function(a,b) {
-				//var x = new Date(a.date);
-				//var y = new Date(b.date);
-				//return ((x < y) ? 1 : ((x > y) ?  -1 : 0));
-				return ((a.version < b.version) ? 1 : ((a.version > b.version) ?  -1 : 0));
-			    });
-			    var limit = 5;
-			    if (self.popularNarratives.length>limit) {
-				self.popularNarratives = self.popularNarratives.slice(0,limit);
-			    }
-			    self.render();
-			},
-			function(err) {
-			    self.popularNarratives=[];
-			    self.render();
-			});
-		},
-		function(err) {
-		    self.popularNarratives=[];
-		    self.render();
-		});
-		
-	},
-	
-	render : function () {
-	    var self = this;
-	    
-	    self.$mainPanel.empty();
-	    
-	    // simple table view
-	    if (self.popularNarratives) {
-		var $tbl = $('<table cellpadding="0" cellspacing="0" border="0" class="table table-bordered table-striped">').css("width","90%");
-		
-		if (self.popularNarratives.length>0) {
-		    for (var k=0; k<self.popularNarratives.length; k++) {
-			var d = new Date(self.popularNarratives[k]["date"]);
-			
-			var time = "";
-			var minutes = d.getMinutes(); if (minutes<10) { minutes = "0"+minutes; }
-			if (d.getHours()>=12) {
-			    if(d.getHours()!=12) { time = (d.getHours()-12) + ":"+minutes+"pm"; }
-			    else { time = "12:"+minutes+"pm"; }
-			} else {
-			    time = d.getHours() + ":"+minutes+"am";
-			}
-			var objhtml = self.popularNarratives[k]["name"]+" (v"+self.popularNarratives[k]["version"]+")<br><i><small>modified on "+
-			self.monthLookup[d.getMonth()]+" "+d.getDate()+", "+d.getFullYear()+" at " + time +
-			"</small></i>";
-			
-			$tbl.append($("<tr>").append($("<td>").append(objhtml)));
-		    }
-		    self.$mainPanel.append($tbl);
-		} else {
-		    self.$mainPanel.append("<b>No visible narratives.</b>");
-		}
-	    }
-	    else {
-		self.$mainPanel.append('<div id="loading-mssg"><p class="muted loader-table"><center><img src="assets/img/ajax-loader.gif"><br><br>searching for recent activity...</center></p></div>');
-	    }
-	    
-	    
-	},
-        monthLookup : ["Jan", "Feb", "Mar","Apr", "May", "Jun", "Jul", "Aug", "Sep","Oct", "Nov", "Dec"]
-    
+define(['jquery', 'nunjucks', 'kbasesocialwidget'], function ($, nunjucks, SocialWidget) {
+	var PopularNarrativesWidget = Object.create(SocialWidget, {
+		init: {
+			value: function (cfg) {
+				cfg.name = 'UserPopularNarratives';
+				cfg.title = 'Popular Narratives';
+				this.SocialWidget_init(cfg);
 
-    });
-})( jQuery )
+				this.templates.env.addFilter('dateFormat', function(dateString) {					
+					var d = new Date(dateString);
+					var shortMonths = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+					var time = "";
+					var minutes = d.getMinutes();
+					if (minutes < 10) {
+						minutes = "0" + minutes;
+					}
+					if (d.getHours() >= 12) {
+						if (d.getHours() != 12) {
+							time = (d.getHours() - 12) + ":" + minutes + "pm";
+						} else {
+							time = "12:" + minutes + "pm";
+						}
+					} else {
+						time = d.getHours() + ":" + minutes + "am";
+					}
+					return shortMonths[d.getMonth()] + " " + d.getDate() + ", " + d.getFullYear() + " at " + time;
+                });
+                this.templates.env.addFilter('typeIcon', function (type) {
+                	var initial = type.charAt(0);
+                	return '<span style="border: 1px red solid; padding: 6px;font-weight: bold; font-size: 150%">' + initial + '</span>';
+                })
+				
+				if (cfg.workspaceURL) {
+					if (this.auth.authToken) {
+						this.workspaceClient = new Workspace(cfg.workspaceURL, {
+							token: this.auth.authToken
+						});
+					} else {
+						this.workspaceClient = new Workspace(cfg.workspaceURL); 
+					}
+				} else {
+					throw 'The workspace client url is not defined';
+				}
+
+				// TODO: get this from somewhere, allow user to configure this.
+				this.params.limit = 10;
+
+                return this;
+			}
+		},
+
+		render: {
+			value: function () {
+				//console.log('Context');
+				//console.log(this.context);
+				this.places.content.html(this.getTemplate('popular_narratives').render(this.context));
+			}
+		},
+
+		getCurrentState: {
+			value: function(cfg) {
+				// Reset or create the popular narratives list.
+				this.data.popularNarratives = [];
+
+
+				// Note that Narratives are now associated 1-1 with a workspace. 
+				// Some new narrative attributes, such as name and (maybe) description, are actually
+				// stored as attributes of the workspace itself.
+				// At present we can just use the presence of "narrative_nice_name" metadata attribute 
+				// to flag a compatible workspace.
+				var d = new Date();
+				d.setMonth(d.getMonth() - 3);
+				this.workspaceClient.list_workspace_info({					
+					showDeleted: 0,
+					owners: [this.params.userId]
+				}, function(data) {
+					var workspaceIds = [];
+					var workspaceMap = {};
+
+					// First we both transfor each ws info object into a nicer js object,
+					// and filter for modern narrative workspaces.
+					for (var i=0; i<data.length; i++) {
+						//tuple<ws_id id, ws_name workspace, username owner, timestamp moddate,
+						//int object, permission user_permission, permission globalread,
+						//lock_status lockstat, usermeta metadata> workspace_info
+						var wsInfo = {
+							id: data[i][0],
+							name: data[i][1],
+							owner: data[i][2],
+							modified: data[i][3],
+							object_count: data[i][4],
+							permission: data[i][5],
+							globalread: data[i][6],
+							lockstat: data[i][7],
+							metadata: data[i][8]
+						};
+
+						if (wsInfo.metadata.narrative_nice_name) {
+							workspaceIds.push(wsInfo.id);
+							workspaceMap[wsInfo.name] = wsInfo;
+						}
+					}
+
+					// Then we need to get the actual narratives because we need the ids in order
+					// to form a url.
+					// NB this is a bit awkward -- perhaps there will be a way soon to open a narrative
+					// just by specifying the workspace.
+
+					// Get details for, sort, and limit the list of workspace objects.
+					if (workspaceIds.length > 0) {
+						
+						var workspacesWithNarratives = {};
+						this.workspaceClient.list_objects({
+								savedby: [this.params.userId],
+								ids: workspaceIds,
+								type: 'KBaseNarrative.Narrative',
+								includeMetadata: 1
+							},
+							function(data) { 
+								for (var i=0; i<data.length; i++) {
+									//console.log('data: ' + i);
+									//console.log(data[i]);
+									//<obj_id objid, obj_name name, type_string type,
+									//timestamp save_date, int version, username saved_by,
+									//ws_id wsid, ws_name workspace, string chsum, int size, usermeta meta>
+									// only consider narratives.
+									// just get the second component of the type name.
+									// var dataType = (data[i][2].split("-")[0]).split("\.")[1];
+									//if (dataType === 'Narrative') {
+									var narrativeInfo = {
+										id: data[i][0],
+										name: data[i][1],
+										type: data[i][2],
+										save_date: data[i][3],
+										version: data[i][4],
+										saved_by: data[i][5],
+										wsid: data[i][6],
+										ws: data[i][7],
+										// type: dataType, 
+										checksum: data[i][8],
+										size: data[i][9],
+										meta: data[i][10],
+										ref: data[i][7] + '/' + data[i][1],
+										obj_id: 'ws.' + data[i][6] + '.obj.' + data[i][0]
+									};
+									var workspaceName = narrativeInfo.ws;
+									if (workspacesWithNarratives[workspaceName]) {
+										this.addWarningMessage('Workspace '+workspaceName+' already has a narrative ' +
+											workspacesWithNarratives[workspaceName].name + ', ' +
+											narrativeInfo.name + ' was skipped.');
+									} else {
+										
+										//var dataType = narrativeInfo.(data[i][2].split("-")[0]).split("\.")[1];
+										var workspaceInfo = workspaceMap[narrativeInfo.ws];
+										if (workspaceInfo) {
+											narrativeInfo.nice_name = workspaceInfo.metadata.narrative_nice_name;
+											narrativeInfo.description = workspaceInfo.metadata.narrative_description;
+											this.data.popularNarratives.push(narrativeInfo);
+										} else {
+											this.addWarningMessage('Workspace ' + narrativeInfo.ws + ' for narrative '+narrativeInfo.name + ' not found.');
+										}
+										
+										workspacesWithNarratives[workspaceName] = narrativeInfo;
+									}
+
+								}
+
+								// Sort by the version, from higher to lower.
+								this.data.popularNarratives.sort(function(a, b) {
+									if (a.version < b.version) {
+										return 1;
+									} else if (a.version > b.version) {
+										return -1;
+									} else {
+										return 0;
+									}
+								});
+								
+								if (this.data.popularNarratives.length > this.params.limit) {
+									this.data.popularNarratives = this.data.popularNarratives.slice(0, this.params.limit);
+								}
+
+								cfg.success();
+
+							}.bind(this),
+							function(err) {
+								cfg.error(err.error.message);
+							}.bind(this));
+					} else {
+						// Didn't find anything, but still considered "success"
+						cfg.success();
+					}
+				}.bind(this),
+				function(err) {
+					cfg.error(err.error.message);
+				}.bind(this));
+			}	
+		}
+
+	});
+
+	return PopularNarrativesWidget;
+});

--- a/src/widgets/social/kbaseUserPopularNarratives.js
+++ b/src/widgets/social/kbaseUserPopularNarratives.js
@@ -140,7 +140,7 @@ define(['jquery', 'nunjucks', 'kbasesocialwidget'], function ($, nunjucks, Socia
 										// type: dataType, 
 										checksum: data[i][8],
 										size: data[i][9],
-										meta: data[i][10],
+										metadata: data[i][10],
 										ref: data[i][7] + '/' + data[i][1],
 										obj_id: 'ws.' + data[i][6] + '.obj.' + data[i][0]
 									};

--- a/src/widgets/social/kbaseUserProfile.js
+++ b/src/widgets/social/kbaseUserProfile.js
@@ -1104,7 +1104,7 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                                     properties: {
                                         gravatar_default: {type: 'string'},
                                         avatar_color: {type: 'string'},
-                                        avatar_initials: {type: 'string'}
+                                        avatar_phrase: {type: 'string'}
                                     }
                                 },
                                 title: {type: 'string'},
@@ -1158,7 +1158,7 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                                     properties: {
                                         gravatar_default: {type: 'string'},
                                         avatar_color: {type: 'string'},
-                                        avatar_initials: {type: 'string'}
+                                        avatar_phrase: {type: 'string'}
                                     }
                                 },
                                 title: {type: 'string'},
@@ -1601,8 +1601,8 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                 for (var i=0; i<fieldsToCheck.length; i++) {
                     var value = this.getProp(this.userRecord, fieldsToCheck[i]);
                     if (fieldsToCheck[i] === 'profile.personal_statement') {
-                        console.log('PERSONAL: ');
-                        console.log(value);
+                        // console.log('PERSONAL: ');
+                        // console.log(value);
                     }
                     if (this.isBlank(value)) {
                         missing.push(fieldsToCheck[i]);

--- a/src/widgets/social/kbaseUserProfile.js
+++ b/src/widgets/social/kbaseUserProfile.js
@@ -14,7 +14,8 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
 
                 this.userProfileService = {
                     // host: 'dev19.berkeley.kbase.us'
-                    url:'https://kbase.us/services/user_profile/rpc'
+                    url:'http://dev19.berkeley.kbase.us/services/user_profile/rpc'
+                    // url:'https://kbase.us/services/user_profile/rpc'
                 }
 
                 // Give ourselves the ability to show templates.
@@ -149,8 +150,28 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
         */
         calcState: {
             value: function () {
+              
+              if (this.userRecord) {
+                if (this.userRecord.user) {
+                  if (this.userRecord.profile) {
+                    this.profileStatus = 'profile';
+                  } else {
+                    this.profileStatus = 'stub';
+                  }
+                } else {
+                  this.profileStatus = 'error';
+                }
+              } else {
+                this.profileStatus = 'none';
+              }
+              
+              if (this.profileStatus === 'profile') {
+                if (this.accountRecord) {
+                  this.userRecord.profile.account = this.accountRecord;
+                }
+              }
 
-                if (this.userRecord) {
+              /*  if (this.userRecord) {
                     this.hasProfile = true;
                     if (this.accountRecord) {
                         this.userRecord.profile.account = this.accountRecord;
@@ -161,6 +182,7 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                         this.hasAccount = true;
                     }
                 }
+                */
 
                 // Context for templates -- should be a separate method.
                 this.context.profileStatus = this.getProfileStatus();
@@ -333,14 +355,13 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                         success: function (data) {
                             this.accountRecord = data;
                             if (data) {
-                                this.hasAccount = true;
                                 this.userRecord.profile.account = {
                                     realname: data.fullName,
                                     email: data.email,
                                     username: data.userName
                                 };
                             } else {
-                                this.hasAccount = false;
+                              delete this.accountRecord;
                             	this.renderErrorView({
                             		title: 'Error', 
                             		message: 'No information returned about the user account'
@@ -1513,16 +1534,18 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                             if (cfg.error) {
                                 cfg.error({
                                     title: 'User not found',
-                                    message: 'No account information found for this user.'
+                                    message: 'No account information found for this user (empty data).'
                                 });
                             }
                         }
                     }.bind(this), 
                     function(err) {
                         if (cfg.error) {
+                          console.log('ERROR');
+                          console.log(err);
                             cfg.error({
                                 title: 'User not found',
-                                message: 'No account information found for this user.'
+                                message: 'No account information found for this user ' + cfg.userId
                             });
                         }
                     }.bind(this)
@@ -1553,7 +1576,7 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
             value: function () {
                 // if profile is present
                 var status = null;
-                if (!this.hasProfile) {
+                if (this.profileStatus !== 'profile') {
                     return {
                         status: 'none'
                     }
@@ -1634,7 +1657,9 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                    return true;
                 } else if (typeof value === 'object') {
                     //console.log('STATUS ' + requiredFields[i] + ':' + value.push);
-                    if (value.push && value.pop) {
+                    if (value === null) {
+                        return true;
+                    } else if (value.push && value.pop) {
                         if (value.length === 0) {
                             return true;
                         }
@@ -1732,11 +1757,15 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                     this.places.title.html('Unauthorized');
                     this.renderPicture();
                     this.places.content.html(this.getTemplate('unauthorized').render(this.context));
-                } else if (this.hasProfile) {
+                } else if (this.profileStatus === 'profile') {
                     // Title can be be based on logged in user infor or the profile.
                     this.renderViewEditLayout();
                     this.renderInfoView();
-                } else if (this.hasAccount) {
+                } else if (this.profileStatus === 'stub') {
+                      // Title can be be based on logged in user infor or the profile.
+                      this.places.title.html(this.userRecord.user.realname + ' (' + this.userRecord.user.username + ')');
+                      this.renderStubProfileView();
+                } else if (this.accountRecord) {
                     // no profile, but have basic account info.
                     this.places.title.html(this.accountRecord.fullName + ' (' + this.accountRecord.userName + ')');
                     this.renderPicture();
@@ -1904,7 +1933,29 @@ define(['nunjucks', 'jquery', 'md5', 'kbaseuserprofileserviceclient'], function 
                             success: function () {
                                 this.renderViewEditLayout();
                                 this.renderPicture();
-                                this.renderEditView();
+                                //this.renderEditView();
+                                this.addSuccessMessage('Success!', 'Your user profile has been created.');
+                            }.bind(that),
+                            error: function (err) {
+                                this.renderErrorView(err);
+                            }.bind(that)
+                        });
+                    });
+                }
+            }
+        },
+        
+        renderStubProfileView: {
+            value: function() {
+                this.places.content.html(this.getTemplate('stub_profile').render(this.context));
+                var that = this;
+                if (this.isProfileOwner) {
+                    $('[data-button="create-profile"]').on('click', function(e) {
+                        that.createUserRecord({
+                            success: function () {
+                                this.renderViewEditLayout();
+                                this.renderPicture();
+                                //this.renderEditView();
                                 this.addSuccessMessage('Success!', 'Your user profile has been created.');
                             }.bind(that),
                             error: function (err) {

--- a/src/widgets/social/kbaseUserRecentActivity.js
+++ b/src/widgets/social/kbaseUserRecentActivity.js
@@ -189,6 +189,8 @@ define(['jquery', 'nunjucks', 'kbasesocialwidget'], function ($, nunjucks, Socia
 								this.data.recentActivity.forEach(function (x) {
 									recentActivityMap[x.ref] = x;
 								});
+                
+                cfg.success();
 								
 							}.bind(this),
 							function(err) {

--- a/src/widgets/social/kbaseUserRecentActivity.js
+++ b/src/widgets/social/kbaseUserRecentActivity.js
@@ -135,39 +135,48 @@ define(['jquery', 'nunjucks', 'kbasesocialwidget'], function ($, nunjucks, Socia
 									// var dataType = (data[i][2].split("-")[0]).split("\.")[1];
 									//if (dataType === 'Narrative') {
 									var narrativeInfo = {
+										id: data[i][0],
 										name: data[i][1],
+										type: data[i][2],
+										save_date: data[i][3],
+										version: data[i][4],
+										saved_by: data[i][5],
+										wsid: data[i][6],
 										ws: data[i][7],
-										ref: data[i][7] + '/' + data[i][1],
 										// type: dataType, 
-										date: data[i][3],
 										checksum: data[i][8],
+										size: data[i][9],
+										metadata: data[i][10],
+										ref: data[i][7] + '/' + data[i][1],
 										obj_id: 'ws.' + data[i][6] + '.obj.' + data[i][0]
 									};
-									var workspaceName = narrativeInfo.ws;
-									if (workspacesWithNarratives[workspaceName]) {
-										this.addWarningMessage('Workspace '+workspaceName+' already has a narrative ' +
-											workspacesWithNarratives[workspaceName].name + ', ' +
+               	  var workspaceInfo = workspaceMap[narrativeInfo.ws];
+                  
+									if (workspacesWithNarratives[narrativeInfo.ws]) {
+										this.addWarningMessage('Workspace '+narrativeInfo.ws+' already has a narrative ' +
+											workspacesWithNarratives[narrativeInfo.ws].name + ', ' +
 											narrativeInfo.name + ' was skipped.');
-									} else {
-										
+									} else {										
 										//var dataType = narrativeInfo.(data[i][2].split("-")[0]).split("\.")[1];
 										var workspaceInfo = workspaceMap[narrativeInfo.ws];
 										if (workspaceInfo) {
-											narrativeInfo.nice_name = workspaceInfo.metadata.narrative_nice_name;
-											narrativeInfo.description = workspaceInfo.metadata.narrative_description;
-											this.data.recentActivity.push(narrativeInfo);
+                      if (workspaceInfo.metadata.narrative_nice_name === narrativeInfo.metadata.name) {
+                        // only keep the narrative with a matching name.
+											  narrativeInfo.nice_name = workspaceInfo.metadata.narrative_nice_name;
+											  narrativeInfo.description = workspaceInfo.metadata.narrative_description;
+											  this.data.recentActivity.push(narrativeInfo);
+                        workspacesWithNarratives[narrativeInfo.ws] = narrativeInfo;
+                      } else {
+                        this.addWarningMessage('Narrative '+ narrativeInfo.name + ' does not match the workspace narrative ' + workspaceInfo.metadata.narrative_nice_name);
+                      }
 										} else {
 											this.addWarningMessage('Workspace ' + narrativeInfo.ws + ' for narrative '+narrativeInfo.name + ' not found.');
 										}
-										
-										workspacesWithNarratives[workspaceName] = narrativeInfo;
 									}
-
 								}
 
 								// We should now have the list of recently active narratives.
 								// Now we sort and limit the list.
-
 								this.data.recentActivity.sort(function(a, b) {
 									var x = new Date(a.date);
 									var y = new Date(b.date);
@@ -180,33 +189,7 @@ define(['jquery', 'nunjucks', 'kbasesocialwidget'], function ($, nunjucks, Socia
 								this.data.recentActivity.forEach(function (x) {
 									recentActivityMap[x.ref] = x;
 								});
-
-								var wsrefs = this.data.recentActivity.map(function (x) {
-									return {
-										ref: x.ref
-									};
-								});
-
-								cfg.success();
-
-								/*
-								this.workspaceClient.get_objects(wsrefs, 
-									function (wsobjs) {
-										for (var i=0; i<wsobjs.length; i++) {
-											var wsobj = wsobjs[i];
-											var ref = wsobj.info[7] + '/' + wsobj.info[1];
-											var recent = recentActivityMap[ref];
-											if (recent) {
-												recent.ws_object = wsobj;
-											} 
-										}
-										cfg.success();
-									}.bind(this), 
-									function (err) {
-										cfg.error(err.error.message);
-									}
-								);
-								*/
+								
 							}.bind(this),
 							function(err) {
 								cfg.error(err.error.message);

--- a/src/widgets/social/templates/userProfile_edit.html
+++ b/src/widgets/social/templates/userProfile_edit.html
@@ -77,7 +77,7 @@
 	</div>
 
 	<div class="panel panel-default">
-	  <div class="panel-heading"><h3 class="panel-title">Your Gravatar</h3></div>
+	  <div class="panel-heading"><h3 class="panel-title">Your Avatar</h3></div>
 	    <div class="panel-body">
 	      <div class="row">
 	        <div class="col-md-3">
@@ -86,6 +86,7 @@
 	        	
 	        </div>
 	        <div class="col-md-9">
+	        	<h3>Gravatar</h3>
 	        	<p>Your gravatar is based on an image you have associated with your email address at <a href="http://en.gravatar.com">Gravatar</a>, a free public profile service from Automattic, the same people who brought us Wordpress. If you have a gravatar associated with the email address in this profile, we will display it within KBase.</p>
 	        	<p>If you don't have a personal gravator, or prefer not to use one, you may select one of the default auto-generated gravatars provided below.</p>
 
@@ -104,7 +105,7 @@
 			           		var v = $(this).val();
 			           		if (v.length > 0) {
 			           			$('[data-field="profile.avatar.avatar_color"] option').prop('selected', false);
-			           			$('[data-field="profile.avatar.avatar_initials"]').val('');
+			           			$('[data-field="profile.avatar.avatar_phrase"] input').val('');
 			           		}
 			           	});
 			           	</script>
@@ -116,7 +117,9 @@
 		           </div>-->
 	        	</div>
 
-	        	<p>Or you may disable the gravatar service completely and use a solid color with your initials</p>
+	        	<h3>A Personal Message Box</h3>
+
+	        	<p>Or you may disable the gravatar service completely and use a solid color with a short phrase.</p>
 
 	        	<div class="form-group" data-field="profile.avatar.avatar_color">
 	        		<label for="avatar_color" class="control-label col-md-3">A Solid Color</label>
@@ -139,10 +142,10 @@
 			           	<div data-element="message" class="help-block"></div>
 		           </div>
 	        	</div>
-	        	<div class="form-group" data-field="profile.avatar.avatar_initials">
-	        		<label for="avatar-initials" class="control-label col-md-3">Your Initials</label>
+	        	<div class="form-group" data-field="profile.avatar.avatar_phrase">
+	        		<label for="avatar-phrase" class="control-label col-md-3">Your Phrase</label>
 		           <div class="col-md-9">
-		           		<input id="avatar-initials" type="text" class="form-control" value="{{userRecord.profile.avatar.avatar_initials}}">
+		           		<input id="avatar-phrase" type="text" class="form-control" value="{{userRecord.profile.avatar.avatar_phrase}}">
 		           		<div data-element="message" class="help-block"></div>
 		           </div>
 	        	</div>

--- a/src/widgets/social/templates/userProfile_error.html
+++ b/src/widgets/social/templates/userProfile_error.html
@@ -1,6 +1,9 @@
 <p>An error has been encountered.</p>
-
+{% if message %}
 {{message | kbmarkup}}
+{% else %}
+No message
+{% endif %}
 
 <!--
 <hr>

--- a/src/widgets/social/templates/userProfile_picture.html
+++ b/src/widgets/social/templates/userProfile_picture.html
@@ -1,7 +1,7 @@
 {%if userRecord.profile.avatar.gravatar_default and userRecord.profile.email %} 
 	<img src="{{userRecord.profile.email | gravatar(200,"pg",userRecord.profile.avatar.gravatar_default)}}" width="95%" style="max-width: 300px;">
 {% elif userRecord.profile.avatar.avatar_color %}
-	<div style="width: 95%; height: 0; padding-bottom: 100%; background-color: {{userRecord.profile.avatar.avatar_color|avatarBackgroundColor}}; color: {{userRecord.profile.avatar.avatar_color|avatarTextColor}};"><div style="padding: 6px;">{{userRecord.profile.avatar.avatar_initials}}</div></div>
+	<div style="width: 95%; height: 0; padding-bottom: 100%; background-color: {{userRecord.profile.avatar.avatar_color|avatarBackgroundColor}}; color: {{userRecord.profile.avatar.avatar_color|avatarTextColor}};"><div style="padding: 6px;">{{userRecord.profile.avatar.avatar_phrase}}</div></div>
 {% else %}
 	<center><img src="assets/images/nouserpic.png" width="95%" style="max-width: 300px;"></center>
 {% endif %}

--- a/src/widgets/social/templates/userProfile_stub_profile.html
+++ b/src/widgets/social/templates/userProfile_stub_profile.html
@@ -1,0 +1,25 @@
+
+{#
+<h2>{{ userRecord.user.realname }}</h2>
+<h3>{{ userRecord.user.username }}</h3>
+#}
+
+{% if env.isOwner %}
+<p class="alert alert-warning">You do not have a public profile yet. Enhance your KBase presence with a public profile.</p>
+<h3>What is a KBase Public Profile?</h3>
+<p>A KBase profile is simply a set of facts about that you that you establish about yourself, including a photo or avatar, your affiliations, the type of work you do, and a personal statement. The profile editor is available to each KBase member, and only a member may change the profile. Changes you make to it are instantly active.</p>
+
+<h3>Who can see the profile?</h3>
+
+<p>Your profile is is visible to all KBase members and staff through the KBase web applications, and the public at large through the standard public profile viewer page.</p>
+
+<h3>Why have a KBase profile</h3>
+<p>Having a profile makes it easier for other users to become familiar with you and your work, and to which facilitates the global knowledge sharing vision of KBase.</p>
+
+
+<button type="button" class="btn btn-primary" data-button="create-profile">Create Your Public KBase Profile Now <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span></button>
+{% else %} 
+<p>This user does not have a profile.</p>
+{% endif %}
+<p>(stub)</p> 
+                        


### PR DESCRIPTION
Sorry, bunch of changes here in just a few commits. Essentially this puts the profile widget into compliance with having stub profiles for all users who haven't created one, and automatically populating them when a user accesses their profile for the first time. A painful change was to move most of what we think of as the "profile" -- the fields a user can change -- into a sub-property "userdata". This allows for having a metadata and account property of a profile. Changing something like this requires changes to templates, json schema, and the widget code. Also cleaned up state user profile state handling, which was changed in accordance with the "stub" profile (previously the code had to handle missing profiles by fetching globus data -- not this only happens when stub profile is created.)
The user profile widget should work with existing profiles, but it may wipe out fields since they won't be in the expected places. I'll probably want to run a script to massage existing stub profiles to add the metadata (right now only the creation data, but soon adding modified date.)