### PR TITLE
Narrative dev

### DIFF
--- a/functional-site/js/app.js
+++ b/functional-site/js/app.js
@@ -706,10 +706,6 @@ app.run(function ($rootScope, $state, $stateParams, $location) {
 
     $('#signin-button').kbaseLogin();
     
-    postal.channel('session').subscribe('#', function (data, env) {
-      console.log(env);
-    });
-    
     // This is an important part of the app lifecycle!
     // Login and out events trigger a refresh of the entire page. 
     // In addition, logout will redirect to the login page.

--- a/src/widgets/kbaseAuthenticatedWidget.js
+++ b/src/widgets/kbaseAuthenticatedWidget.js
@@ -96,7 +96,7 @@
 
         loggedInQueryCallback : function(args) {
             if (this.loggedInCallback) {
-                this.loggedInCallback({},args);
+                this.loggedInCallback(undefined,args);
             }
         },
 

--- a/src/widgets/kbaseAuthenticatedWidget.js
+++ b/src/widgets/kbaseAuthenticatedWidget.js
@@ -31,17 +31,21 @@
             // from the KBaseSessionSync jquery extension.
             var sessionObject = $.KBaseSessionSync.getKBaseSession();
             this.setAuth(sessionObject);
-            if (this.loggedInQueryCallback && sessionObject && sessionObject.token) {
+            
+            // This is how to pull the value out of the auth attribute.
+            var auth = this.auth();
+            if (this.loggedInQueryCallback && auth && auth.token) {
               this.callAfterInit(function () {
-                 this.loggedInQueryCallback(sessionObject);
+                // use the current auth attribute value, since this is run asynchronously, and who knows,
+                // it may have changed.
+                 this.loggedInQueryCallback(this.auth());
               }.bind(this));
             }
            
-
             postal.channel('session').subscribe('login.success', function (session) {
                 this.setAuth(session);
                 if (this.loggedInCallback) {
-                    this.loggedInCallback(undefined, session);
+                    this.loggedInCallback(undefined, this.auth());
                 }
               }.bind(this));
 

--- a/src/widgets/kbaseAuthenticatedWidget.js
+++ b/src/widgets/kbaseAuthenticatedWidget.js
@@ -25,15 +25,15 @@
 
         init: function(options) {
 
-            this._super(options);
+            this._super(options); 
             
             // An authenticated widget needs to get the initial auth state
             // from the KBaseSessionSync jquery extension.
             var sessionObject = $.KBaseSessionSync.getKBaseSession();
             this.setAuth(sessionObject);
-            if (this.loggedInQueryCallback && this.sessionObject &&this.sessionObject.token) {
+            if (this.loggedInQueryCallback && sessionObject && sessionObject.token) {
               this.callAfterInit(function () {
-                this.loggedInQueryCallback(sessionObject);
+                 this.loggedInQueryCallback(sessionObject);
               }.bind(this));
             }
            

--- a/src/widgets/kbaseAuthenticatedWidget.js
+++ b/src/widgets/kbaseAuthenticatedWidget.js
@@ -30,10 +30,11 @@
             // An authenticated widget needs to get the initial auth state
             // from the KBaseSessionSync jquery extension.
             var sessionObject = $.KBaseSessionSync.getKBaseSession();
-            if (this.loggedInQueryCallback) {
+            this.setAuth(sessionObject);
+            if (this.loggedInQueryCallback && this.sessionObject &&this.sessionObject.token) {
               this.loggedInQueryCallback(sessionObject);
             }
-            var auth = this.setAuth(sessionObject);
+           
 
             postal.channel('session').subscribe('login.success', function (session) {
                 this.setAuth(session);
@@ -42,7 +43,7 @@
                 }
               }.bind(this));
 
-            postal.channel('session').subscribe('login.success', function (session) {
+            postal.channel('session').subscribe('logout.success', function (session) {
                 this.setAuth(undefined);
                 if (this.loggedOutCallback) {
                     this.loggedOutCallback();
@@ -80,10 +81,12 @@
         },
 
         setAuth : function (newAuth) {
-            this.setValueForKey('auth', newAuth);
-            if (newAuth == undefined) {
-                newAuth = {};
+            if (!newAuth) {
+              newAuth = {};
             }
+            this.setValueForKey('auth', newAuth);
+           
+           
             this.sessionId(newAuth.kbase_sessionid);
             this.authToken(newAuth.token);
             this.user_id(newAuth.user_id);
@@ -93,7 +96,7 @@
 
         loggedInQueryCallback : function(args) {
             if (this.loggedInCallback) {
-                this.loggedInCallback(undefined,args);
+                this.loggedInCallback({},args);
             }
         },
 

--- a/src/widgets/kbaseAuthenticatedWidget.js
+++ b/src/widgets/kbaseAuthenticatedWidget.js
@@ -4,7 +4,7 @@
 
 (function( $, undefined ) {
 
-
+  'use strict';
     $.KBWidget({
 
 		  name: "kbaseAuthenticatedWidget",
@@ -32,14 +32,16 @@
             var sessionObject = $.KBaseSessionSync.getKBaseSession();
             this.setAuth(sessionObject);
             if (this.loggedInQueryCallback && this.sessionObject &&this.sessionObject.token) {
-              this.loggedInQueryCallback(sessionObject);
+              this.callAfterInit(function () {
+                this.loggedInQueryCallback(sessionObject);
+              }.bind(this));
             }
            
 
             postal.channel('session').subscribe('login.success', function (session) {
                 this.setAuth(session);
                 if (this.loggedInCallback) {
-                    this.loggedInCallback(e, session);
+                    this.loggedInCallback(undefined, session);
                 }
               }.bind(this));
 


### PR DESCRIPTION
Scour the authenticated widget to make sure the auth property is set up correctly. Specifically, it is an empty object if unauthenticated, otherwise the standard auth object (un, user_id, token, kbasesession_id).