### PR TITLE
Search

### DIFF
--- a/functional-site/assets/css/search.css
+++ b/functional-site/assets/css/search.css
@@ -106,12 +106,19 @@ span .badge {
     padding-bottom: 5px;
 }
 
-
 .btn-setcopy:focus,
 .btn-setcopy:active,
 .btn-setcopy.active {
     color: #ffffff;
     background-color: #6f5499;
+}
+
+
+.btn-select-narrative {
+    position: relative;
+    font-size: 12px!important;
+    left: -16px;
+    top: -37px;
 }
 
 
@@ -137,6 +144,11 @@ span .badge {
     padding: 0px;
 }
 
+.search-navbar-title {
+    padding-left: 40px;
+    font-size: 20px;
+    color: gray;    
+}
 
 /*** Login ***/
 
@@ -938,20 +950,20 @@ table.search-transfer-table {
 }
 
 .metagenome_sequence_type_header {
-    width: 100px;
+    width: 110px;
 }
 
 .metagenome_sequence_type {
-    width: 92px;
+    width: 102px;
     margin-right: 8px;
 }
 
 .metagenome_biome_header {
-    width: 358px;
+    width: 348px;
 }
 
 .metagenome_biome {
-    width: 340px;
+    width: 330px;
     margin-right: 8px;
 }
 

--- a/functional-site/views/404.html
+++ b/functional-site/views/404.html
@@ -3,11 +3,13 @@
         <h1>404 Page not found!?</h1>
     </div>
     <div class="row">
-        <div class="col-md-12">
-            <h4>
-                <p>We were unable to find the page you were looking for.
-                If this seems to be an error, please contact <a href="mailto:help@kbase.us">help@kbase.us</a>.</p>
-            </h4>
+        <div class="col-md-7">
+            <image src="./assets/images/404.jpg" class="animated fadeInUpBig"/>
+        </div>
+        <div class="col-md-5">
+            <h3>
+                <p>We were unable to find the page you were looking for.  If this seems to be an error, please contact <a href="mailto:help@kbase.us">help@kbase.us</a>.</p>
+            </h3>
         </div>
     </div>
 </div>

--- a/functional-site/views/search/categories/features/features_rows.html
+++ b/functional-site/views/search/categories/features/features_rows.html
@@ -1,6 +1,6 @@
 <div class="col-xs-3 col-sm-3 col-md-2 col-lg-2 search-result-column feature_id">
     <span>
-        <a target='_blank' data-trigger="hover" class="feature_id" href="{{options.landingPagePrefix}}{{item.workspace_name}}/{{item.genome_id}}?sub=Feature&subid={{item.feature_id}}">
+        <a target='_blank' data-trigger="hover" class="feature_id" href="{{options.landingPagePrefix}}{{item.workspace_name.split('Rich').join('')}}/{{item.genome_id}}?sub=Feature&subid={{item.feature_id}}">
             <strong><em>{{item.feature_id}}</em></strong>
         </a>
     </span>
@@ -11,7 +11,7 @@
 <div class="col-xs-3 col-sm-3 col-md-2 col-lg-2 search-result-column feature_source_id">{{item.feature_source_id}}</div>
 <div class="col-xs-3 col-sm-3 col-md-2 col-lg-2 search-result-column feature-scientific-name">
     <span>
-        <a target='_blank' class="feature-scientific-name" href="{{options.landingPagePrefix}}{{item.workspace_name}}/{{item.genome_id}}">
+        <a target='_blank' class="feature-scientific-name" href="{{options.landingPagePrefix}}{{item.workspace_name.split('Rich').join('')}}/{{item.genome_id}}">
             <strong><em>{{item.scientific_name}}</em></strong>
         </a>
     </span>

--- a/functional-site/views/search/categories/genomes/genomes_rows.html
+++ b/functional-site/views/search/categories/genomes/genomes_rows.html
@@ -1,7 +1,7 @@
 <div class="col-xs-2 col-sm-2 col-md-1 col-lg-1 search-result-column genome_id">{{item.genome_id}}</div>
 <div class="col-xs-2 col-sm-2 col-md-1 col-lg-1 search-result-column genome-scientific-name">
     <span>
-        <a target='_blank' class='genome-scientific-name' href='{{options.landingPagePrefix}}{{item.workspace_name}}/{{item.genome_id}}'>
+        <a target='_blank' class='genome-scientific-name' href='{{options.landingPagePrefix}}{{item.workspace_name.split("Rich").join("")}}/{{item.genome_id}}'>
             <strong><em>{{item.scientific_name}}</em></strong>
         </a>
     </span>

--- a/functional-site/views/search/categories/metagenomes/metagenomes_expanded.html
+++ b/functional-site/views/search/categories/metagenomes/metagenomes_expanded.html
@@ -20,5 +20,5 @@
 </tr>
 <tr ng-if="item.project_url">
     <td class="search-result-column-expanded-entry-cell metagenome_expanded_header"><strong>Project Website: </strong></td>
-    <td class="search-result-column-expanded-entry-cell">{{item.project_url}}</td>
+    <td class="search-result-column-expanded-entry-cell"><a target=_blank href="{{item.project_url}}">{{item.project_url}}</a></td>
 </tr>

--- a/functional-site/views/search/categories/models_fba/models_fba_expanded.html
+++ b/functional-site/views/search/categories/models_fba/models_fba_expanded.html
@@ -6,3 +6,15 @@
     <td class="search-result-column-expanded-entry-cell model_expanded_header"><strong>Genome Id:</strong></td>
     <td class="search-result-column-expanded-entry-cell">{{item.genome_id}}</td>
 </tr>                    
+<tr ng-if="item.number_of_biomasses">
+    <td class="search-result-column-expanded-entry-cell model_expanded_header"><strong>Biomasses:</strong></td>
+    <td class="search-result-column-expanded-entry-cell">{{item.number_of_biomasses}}</td>
+</tr>                    
+<tr ng-if="item.number_of_compartments">
+    <td class="search-result-column-expanded-entry-cell model_expanded_header"><strong>Compartments:</strong></td>
+    <td class="search-result-column-expanded-entry-cell">{{item.number_of_compartments}}</td>
+</tr>                    
+<tr ng-if="item.number_of_gapgens">
+    <td class="search-result-column-expanded-entry-cell model_expanded_header"><strong>Gapgens:</strong></td>
+    <td class="search-result-column-expanded-entry-cell">{{item.number_of_gapgens}}</td>
+</tr>                    

--- a/functional-site/views/search/search.html
+++ b/functional-site/views/search/search.html
@@ -21,7 +21,7 @@
                     -->
 
 
-                    <div ng-hide="options.userState.session.selectedWorkspace" class="alert alert-warning">
+                    <div ng-hide="!options.userState.session.token || options.userState.session.selectedWorkspace" class="alert alert-warning">
                         <div class="text-center">
                             <span class="search-cart-label"><a ng-click="options.userState.session.selectedWorkspace = undefined; listWorkspaces();">Select a Narrative</a></span>
                         </div>
@@ -30,8 +30,10 @@
                         <div class="text-center">
                             <span>Copy to Narrative</span>
                         </div>
+                        <div>
+                            <button type="button" class="btn-xs btn-danger btn-select-narrative" ng-click="options.userState.session.selectedWorkspace = undefined" ng-show="options.userState.session.transfer_cart.size == 0 && !options.transferring"><span class="glyphicon glyphicon-remove-sign"></span></button>
+                        </div>
                         <div class="text-center">
-                            <button type="button" class="btn-xs btn-danger" ng-click="options.userState.session.selectedWorkspace = undefined; listWorkspaces();" ng-show="options.userState.session.transfer_cart.size == 0 && !options.transferring"><span class="glyphicon glyphicon-remove-sign"></span></button>
                             <span class="glyphicon glyphicon-hdd"></span>
                             <span class="search-cart-label">{{options.userState.session.selectedWorkspaceName}}</span>
                             <span class="badge badge-info" ng-repeat="w in options.userState.longterm.workspaces" ng-if="w[1] == options.userState.session.selectedWorkspace">{{w[4]}}</span>
@@ -103,6 +105,7 @@
                                     <span> </span>
                                     <span class="glyphicon glyphicon-file"></span>
                                 </button>
+                                <!--
                                 <button rel="tooltip" tooltip="Transfer my selections as a set to Narratives." tooltip-placement="bottom" data-placement="bottom" data-toggle="modal" data-target="#transferPanel" type="button" ng-class="{'disabled': options.userState.session.data_cart.size < 1 || !options.userState.session.selectedWorkspace || !options.userState.session.set[options.selectedCategory]}" class='btn btn-setcopy' ng-click="copySet(options.selectedCategory)">
                                     <span class="glyphicon glyphicon-hdd"></span>
                                     <span> </span>
@@ -110,6 +113,7 @@
                                     <span> </span>
                                     <span class="glyphicon glyphicon-book"></span>
                                 </button>
+                                -->
                                 <button data-toggle="tooltip" data-placement="bottom" tooltip="Discard my data selections." tooltip-placement="bottom" type="button" ng-class="{'disabled': options.userState.session.data_cart.size < 1}" class='btn btn-danger' ng-click='emptyCart()'>
                                     <span class="glyphicon glyphicon-trash"></span>
                                 </button>              
@@ -228,12 +232,6 @@
                         <div class="row">                        
                             <table>
                                 <h3>Objects that match <i>{{options.searchOptions.general.q}}</i></h3>
-<!--                                
-                                <tr>
-                                    <th><h4>Category</h4></th>
-                                    <th class="search-space-left"><h4 class="search-space-left">Objects found</h4></th>
-                                </tr>
--->
                                 <tr ng-if="options.searchCategories[p.category] && options.categoryCounts[p.category] > 0" ng-repeat="p in options.categoryInfo.displayTree['unauthenticated'].children">
                                     <td class="search-category-title" ng-click="selectCategory(p.category)">
                                         <a><span>{{p.label}}</span></a>


### PR DESCRIPTION
* Put text and narrative icon in the title bar.
* Shrank button for deselecting a narrative and put it in the upper left corner of the panel.
* Corrected genome landing page links.
* Corrected feature landing page links.
* Removed set copy button.
* Slightly modified metagenome column spacing because sequence type was too close to biome.
* Included biomasses, compartments, gapgens info in the expanded info for models.
* Made a link to the project url in the expanded metagenome info that opens in a new tab or window.
* V5 genomes and features will now copy correctly.