### PR TITLE
Update Narrative Welcome Cell content as per https://atlassian.kbase.us/browse/NAR-697

### DIFF
--- a/functional-site/assets/css/kb-bootstrap.css
+++ b/functional-site/assets/css/kb-bootstrap.css
@@ -50,3 +50,12 @@
    font-size: 18px;
 }
 
+.form-control-kbase {
+   border-radius: 1px;
+}
+.well-kbase {
+   border-radius: 1px;
+}
+.alert-kbase {
+   border-radius: 1px;
+}

--- a/functional-site/config.json
+++ b/functional-site/config.json
@@ -29,8 +29,8 @@
          }
       },
       "docsite": {
-         "baseUrl": "http://staging.kbase.us",
-         "host": "staging.kbase.us",
+         "baseUrl": "http://kbase.us",
+         "host": "kbase.us",
          "paths": {
             "about": "/what-is-kbase",
             "contact": "/contact-us",
@@ -66,8 +66,8 @@
          }
       },
       "docsite": {
-         "host": "staging.kbase.us",
-         "baseUrl": "http://staging.kbase.us",
+         "host": "kbase.us",
+         "baseUrl": "http://kbase.us",
          "paths": {
             "about": "/what-is-kbase",
             "contact": "/contact-us",
@@ -103,8 +103,8 @@
          }
       },
       "docsite": {
-         "host": "staging.kbase.us",
-         "baseUrl": "http://staging.kbase.us",
+         "host": "kbase.us",
+         "baseUrl": "http://kbase.us",
          "paths": {
             "about": "/what-is-kbase",
             "contact": "/contact-us",

--- a/functional-site/index.html
+++ b/functional-site/index.html
@@ -8,7 +8,7 @@
    <!-- external css -->
    <link rel="stylesheet" type="text/css" href="/ext/bootstrap/3.3.2/css/bootstrap.min.css" />
    <!-- jquery-ui-1.10.0.custom.css is needed for the landing page card layout, some old landing pages still use this style -->
-   <link rel="stylesheet" type="text/css" href="/ext/jquery-ui/1.10.3/css/custom-theme/jquery-ui-1.10.0.custom.css">
+   <!--<link rel="stylesheet" type="text/css" href="/ext/jquery-ui/1.10.3/css/custom-theme/jquery-ui-1.10.0.custom.css">-->
 
    <!-- DataTable 1.10.4 css dependencies. 2014-01-29 eap -->
    <!-- <link rel="stylesheet" type="text/css" href="assets/css/dataTables.bootstrap.css" /> -->
@@ -109,7 +109,7 @@
 
    <script src="/ext/jquery/jquery-1.10.2.min.js"></script>
    <!-- <script src="../ext/jquery-migrate/jquery-migrate-1.2.1.js"></script> -->
-   <script src="/ext/jquery-ui/1.10.3/js/jquery-ui-1.10.3.custom.min.js"></script>
+  <!-- <script src="/ext/jquery-ui/1.10.3/js/jquery-ui-1.10.3.custom.min.js"></script>-->
    <script src="/ext/blockUI/jquery.blockUI.js"></script>
    <script src="/ext/bootstrap/3.3.2/js/bootstrap.js"></script>
    <script src="/ext/d3/d3.v3.min.js"></script>

--- a/functional-site/js/controllers.js
+++ b/functional-site/js/controllers.js
@@ -559,10 +559,15 @@ app
     
     // callback for ng-click 'loginUser':
     $scope.loginUser = function (user, nextPath) {
+				// TODO: this should not be an ID!!
         $("#loading-indicator").show();
+				// Angular does not populate the user property if nothing
+				// was filled in.
+				var username = user?user.username:null;
+				var password = user?user.password:null;
         kbaseLogin.login(
-            user.username,
-            user.password
+            username,
+            password
         );
     };
 

--- a/functional-site/js/controllers.js
+++ b/functional-site/js/controllers.js
@@ -541,6 +541,14 @@ app
         $location.path('/dashboard');
         return;
     }
+
+   require(['kb.widget.navbar'], function (NAVBAR) {
+      NAVBAR.clearMenu()
+      .addDefaultMenu({
+        search: false, narrative: false, dashboard: false
+      })
+      .setTitle("Sign In to KBase");
+   });
     
     $scope.nar_url = configJSON.narrative_url; // used for links to narratives
     
@@ -559,12 +567,13 @@ app
     
     // callback for ng-click 'loginUser':
     $scope.loginUser = function (user, nextPath) {
-				// TODO: this should not be an ID!!
+       // TODO: this should not be an ID!!
         $("#loading-indicator").show();
-				// Angular does not populate the user property if nothing
-				// was filled in.
-				var username = user?user.username:null;
-				var password = user?user.password:null;
+       // Angular does not populate the user property if nothing
+       // was filled in.
+       var username = user?user.username:null;
+       var password = user?user.password:null;
+        $("#login_error").hide();
         kbaseLogin.login(
             username,
             password

--- a/functional-site/views/login.html
+++ b/functional-site/views/login.html
@@ -1,39 +1,46 @@
 <div class="container" style="margin-top: 4em; ">
-<div style="xposition: relative;">
-	<div style="position: absolute; background-image: url(assets/images/doodle.png); background-repeat: no-repeat; background-size: 35%; border: 0px red solid;  top: 0; left: 0; right: 0; bottom: 0; opacity: 0.1"></div>
+   <div style="xposition: relative;">
+      <div style="position: absolute; background-image: url(assets/images/doodle.png); background-repeat: no-repeat; background-size: 35%; border: 0px red solid;  top: 0; left: 0; right: 0; bottom: 0; opacity: 0.1"></div>
+   </div>
+   <div class="row" style="">
+      <div class="col-sm-7 col-sm-offset-1">
+         <!--<p id="doodle" class="text-center"><img src="assets/images/doodle.png" /></p>-->
+         <h1 style="font-size: 1.6em">Welcome to the KBase Search and Narrative Interface</h1>
+         <p>After signing in you can upload your own experimental data or find data integrated from external resources or shared by other users. You can then perform, organize, and share sophisticated comparative genomics and systems biology analyses by creating Narratives.</p>
+         <p>Narratives are user-created interactive, dynamic, and shareable documents that are KBase’s way of making systems biology research transparent, reproducible, and reusable.</p>
+         <p>The Narrative Interface lets you customize and execute a set of ordered KBase analyses to create your own Narratives that include your analysis steps, commentary, visualizations, and custom scripts.</p>
+         <p>Want to learn more? We have an extensive and growing <a href="http://kbase.us/tutorials">library of tutorials</a> that show you how to use KBase’s new apps to analyze your data. To become familiar with the user interface, try the <a href="http://kbase.us/narrative-guide">Narrative Interface User Guide</a>.
+      </div>
+      <div class="col-sm-3">
+         <div class="well">
+            <form autofill-fix id="xlogin-form" class="form login-form" ng-hide="loggedIn()" ng-submit="loginUser(user, nextPath)">
+               <input type="hidden" ng-model="nextPath">
+               <div class="row">
+                  <div class="col-sm-12">
+                     <legend style="text-align: center;">KBase Sign In</legend>
+
+                     <div class="form-group">
+                        <!--<label for="kbase_username">Username:</label>-->
+                        <input name="kbase_username" type="text" placeholder="username" id="kbase_username" class=" form-control" tabindex="1" ng-model="user.username" required>
+                     </div>
+                     <div class="form-group">
+                        <!--<label for="kbase_password" class="full-width">Password:</label>-->
+                        <input type="password" placeholder="password" id="kbase_password" class="form-control" tabindex="2" ng-model="user.password" required>
+                     </div>
+                     <div class="form-group">
+                        <button id="signinbtn" type="submit" class="btn btn-primary btn-block btn-kbase" tabindex="3">Sign In<span id="loading-indicator" style="display: none;"> <i class="fa fa-spinner fa-spin"></i></span>
+                        </button>
+                        <div id="login_error" class="alert alert-danger" style="display:none; margin-top: 1em;"></div>
+                     </div>
+                     <div class="form-group" style="margin-top: 3em; margin-bottom: 0">
+                           <a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-block btn-link">New to KBase? Sign Up</a>
+                           <a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-block btn-link">Forgot your password?</a>
+                           <a target="_blank" href="http://kbase.us/login-help" class="btn btn-block btn-link">Help</a>
+                     </div>
+                  </div>
+               </div>
+            </form>
+         </div>
+      </div>
+   </div>
 </div>
-<div class="row" style="">
-    <div class="col-sm-7 col-sm-offset-1"  >
-		    <!--<p id="doodle" class="text-center"><img src="assets/images/doodle.png" /></p>-->
-					<h1 style="font-size: 1.6em">Welcome to the KBase Search and Narrative Interface</h1>
-					<p>After signing in you can upload your own experimental data or find data integrated from external resources or shared by other users. You can then perform, organize, and share sophisticated comparative genomics and systems biology analyses by creating Narratives.</p>
-					<p>Narratives are user-created interactive, dynamic, and shareable documents that are KBase’s way of making systems biology research transparent, reproducible, and reusable.</p>
-					<p>The Narrative Interface lets you customize and execute a set of ordered KBase analyses to create your own Narratives that include your analysis steps, commentary, visualizations, and custom scripts.</p>
-					<p>Want to learn more? We have an extensive and growing <a href="http://kbase.us/tutorials">library of tutorials</a> that show you how to use KBase’s new apps to analyze your data. To become familiar with the user interface, try the <a href="http://kbase.us/narrative-guide">Narrative Interface User Guide</a>.						
-    </div>
-    <div class="col-sm-3" >
-        <form autofill-fix id="xlogin-form" class="login-form well" ng-hide="loggedIn()" ng-submit="loginUser(user, nextPath)" >
-        		<input type="hidden" ng-model="nextPath">
-            <div class="row">
-                <legend style="text-align: center;">KBase Sign In</legend>
-                
-                <div class="form-group">
-                    <!--<label for="kbase_username">Username:</label>-->
-                    <input name="kbase_username" type="text" placeholder="username" id="kbase_username" class=" form-control" tabindex="1" ng-model="user.username" required>
-                </div>
-                <div class="form-group">
-                     <!--<label for="kbase_password" class="full-width">Password:</label>-->
-                    <input type="password" placeholder="password" id="kbase_password" class="form-control" tabindex="2" ng-model="user.password" required>
-                </div>
-                <button id="signinbtn" type="submit" class="btn btn-primary btn-block btn-kbase" tabindex="3" >Sign In<span id="loading-indicator" style="display: none;"> <i class="fa fa-spinner fa-spin"></i></span></button> 
-								<div id="login_error" class="alert alert-danger" style="display:none; margin-top: 1em;"></div>
-            </div>
-						<div class="row" style="margin-top: 2em;">
-	            <div><a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-link">New to KBase? Sign Up</a></div>
-							<div><a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-link">Forgot your password?</a></div>
-							<div><a target="_blank" href="http://kbase.us/login-help" class="btn btn-link">Help</a></div>
-						</div>
-        </form>
-    </div>
-</div>
-</container>

--- a/functional-site/views/login.html
+++ b/functional-site/views/login.html
@@ -1,51 +1,39 @@
-
-<br><br>
-<div class="row">
-    <div class="col-md-4 col-md-offset-1">
-        <div>
-            <p id="doodle" class="text-center"><img src="assets/images/doodle.png" /></p>
-            <div style="padding-left: 30px">
-            <h1 style="font-size: 1.6em">Your science, your way.</h1>
-            <p>Build narratives that capture your analyses, including rich annotations, visualization widgets, reusable workflows, and
-            custom scripts. Share your work and your data with colleagues. Follow the field through the people, organisms, and projects
-            that matter to you. </p> 
-            </div>  
-        </div>
-                        
+<div class="container" style="margin-top: 4em; ">
+<div style="xposition: relative;">
+	<div style="position: absolute; background-image: url(assets/images/doodle.png); background-repeat: no-repeat; background-size: 35%; border: 0px red solid;  top: 0; left: 0; right: 0; bottom: 0; opacity: 0.1"></div>
+</div>
+<div class="row" style="">
+    <div class="col-sm-7 col-sm-offset-1"  >
+		    <!--<p id="doodle" class="text-center"><img src="assets/images/doodle.png" /></p>-->
+					<h1 style="font-size: 1.6em">Welcome to the KBase Search and Narrative Interface</h1>
+					<p>After signing in you can upload your own experimental data or find data integrated from external resources or shared by other users. You can then perform, organize, and share sophisticated comparative genomics and systems biology analyses by creating Narratives.</p>
+					<p>Narratives are user-created interactive, dynamic, and shareable documents that are KBase’s way of making systems biology research transparent, reproducible, and reusable.</p>
+					<p>The Narrative Interface lets you customize and execute a set of ordered KBase analyses to create your own Narratives that include your analysis steps, commentary, visualizations, and custom scripts.</p>
+					<p>Want to learn more? We have an extensive and growing <a href="http://kbase.us/tutorials">library of tutorials</a> that show you how to use KBase’s new apps to analyze your data. To become familiar with the user interface, try the <a href="http://kbase.us/narrative-guide">Narrative Interface User Guide</a>.						
     </div>
-    <div class="col-md-4 col-md-offset-1" >
-        <form autofill-fix id="login-form" class="login-form well" ng-hide="loggedIn()" ng-submit="loginUser(user, nextPath)" >
-        <input type="hidden" ng-model="nextPath" >
-            <div>
-                <legend>Please sign in</legend>
-                <p id="login_error" class="text-danger" style="display:none"></p>
+    <div class="col-sm-3" >
+        <form autofill-fix id="xlogin-form" class="login-form well" ng-hide="loggedIn()" ng-submit="loginUser(user, nextPath)" >
+        		<input type="hidden" ng-model="nextPath">
+            <div class="row">
+                <legend style="text-align: center;">KBase Sign In</legend>
+                
                 <div class="form-group">
-                   
-                    <label for="kbase_username">Username:</label>
+                    <!--<label for="kbase_username">Username:</label>-->
                     <input name="kbase_username" type="text" placeholder="username" id="kbase_username" class=" form-control" tabindex="1" ng-model="user.username" required>
                 </div>
                 <div class="form-group">
-                    <label for="kbase_password" class="full-width">Password:<span class="pull-right"> <a target="_blank" href="http://gologin.kbase.us/ResetPassword" tabindex="4">&nbsp;Forgot password?</a></span></label>
+                     <!--<label for="kbase_password" class="full-width">Password:</label>-->
                     <input type="password" placeholder="password" id="kbase_password" class="form-control" tabindex="2" ng-model="user.password" required>
                 </div>
-
-                <button id="signinbtn" type="submit" class="btn btn-primary" tabindex="3" >Sign In</button> <img src="./assets/images/ajax-loader.gif" id="loading-indicator" style="display: none;"  />
+                <button id="signinbtn" type="submit" class="btn btn-primary btn-block btn-kbase" tabindex="3" >Sign In<span id="loading-indicator" style="display: none;"> <i class="fa fa-spinner fa-spin"></i></span></button> 
+								<div id="login_error" class="alert alert-danger" style="display:none; margin-top: 1em;"></div>
             </div>
-            <BR>
-            <span>New to KBase? <a target="_blank" href="http://gologin.kbase.us/Signup">Register now</a></span>
+						<div class="row" style="margin-top: 2em;">
+	            <div><a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-link">New to KBase? Sign Up</a></div>
+							<div><a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-link">Forgot your password?</a></div>
+							<div><a target="_blank" href="http://kbase.us/login-help" class="btn btn-link">Help</a></div>
+						</div>
         </form>
-        <form class="login-form well" ng-show="loggedIn()">
-            <div>
-                <legend>Signed in as <span style="white-space:nowrap">{{ username }}</span></legend>
-                <p>
-                    You can navigate KBase using the dropdown menu at the top left.
-                </p>
-                <p>
-                    <a href="#/narrativemanager/start">Click here to enter the Narrative interface.</a>
-                </p>
-                <button class="btn btn-primary" ng-click="logoutUser()">Sign Out</button>
-            </div>
-        </form>
-        
     </div>
 </div>
+</container>

--- a/functional-site/views/login.html
+++ b/functional-site/views/login.html
@@ -12,7 +12,7 @@
          <p>Want to learn more? We have an extensive and growing <a href="http://kbase.us/tutorials">library of tutorials</a> that show you how to use KBase’s new apps to analyze your data. To become familiar with the user interface, try the <a href="http://kbase.us/narrative-guide">Narrative Interface User Guide</a>.
       </div>
       <div class="col-sm-3">
-         <div class="well">
+         <div class="well well-kbase">
             <form autofill-fix id="xlogin-form" class="form login-form" ng-hide="loggedIn()" ng-submit="loginUser(user, nextPath)">
                <input type="hidden" ng-model="nextPath">
                <div class="row">
@@ -21,21 +21,21 @@
 
                      <div class="form-group">
                         <!--<label for="kbase_username">Username:</label>-->
-                        <input name="kbase_username" type="text" placeholder="username" id="kbase_username" class=" form-control" tabindex="1" ng-model="user.username" required>
+                        <input name="kbase_username" type="text" placeholder="username" id="kbase_username" class="form-control form-control-kbase" tabindex="1" ng-model="user.username" required>
                      </div>
                      <div class="form-group">
                         <!--<label for="kbase_password" class="full-width">Password:</label>-->
-                        <input type="password" placeholder="password" id="kbase_password" class="form-control" tabindex="2" ng-model="user.password" required>
+                        <input type="password" placeholder="password" id="kbase_password" class="form-control form-control-kbase" tabindex="2" ng-model="user.password" required>
                      </div>
                      <div class="form-group">
                         <button id="signinbtn" type="submit" class="btn btn-primary btn-block btn-kbase" tabindex="3">Sign In<span id="loading-indicator" style="display: none;"> <i class="fa fa-spinner fa-spin"></i></span>
                         </button>
-                        <div id="login_error" class="alert alert-danger" style="display:none; margin-top: 1em;"></div>
+                        <div id="login_error" class="alert alert-danger alert-kbase" style="display:none; margin-top: 1em;"></div>
                      </div>
                      <div class="form-group" style="margin-top: 3em; margin-bottom: 0">
-                           <a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-block btn-link">New to KBase? Sign Up</a>
-                           <a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-block btn-link">Forgot your password?</a>
-                           <a target="_blank" href="http://kbase.us/login-help" class="btn btn-block btn-link">Help</a>
+                        <a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-block btn-link">New to KBase? Sign Up</a>
+                        <a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-block btn-link">Forgot your password?</a>
+                        <a target="_blank" href="http://kbase.us/login-help" class="btn btn-block btn-link">Help</a>
                      </div>
                   </div>
                </div>

--- a/src/widgets/kbaseNavbar.js
+++ b/src/widgets/kbaseNavbar.js
@@ -1,3 +1,5 @@
+/*global define: true */
+/*jslint browser:true  vars: true */
 define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
    function ($, nunjucks, Session, Config) {
       "use strict";
@@ -103,21 +105,23 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
                //   iconStyle += 'color: ' + cfg.color + ';';
                //}
 
+               var button;
                if (cfg.url) {
                   // a link style button
                   if (cfg.external) {
                      cfg.target = '_blank';
                   }
+                  var target;
                   if (cfg.target) {
-                     var target = 'target="' + cfg.target + '"';
+                     target = 'target="' + cfg.target + '"';
                   } else {
-                     var target = '';
+                     target = '';
                   }
-                  var button = $('<a data-button="' + cfg.name + '" id="kb-' + cfg.name + '-btn" class="btn btn-' + (cfg.style || 'default') + ' navbar-btn kb-nav-btn" role="button" href="' + cfg.url + '" ' + target + '>' +
-                     '  <div class="fa fa-' + cfg.icon + '" style="' + iconStyle + '"></div>' + label + '</a>')
+                  button = $('<a data-button="' + cfg.name + '" id="kb-' + cfg.name + '-btn" class="btn btn-' + (cfg.style || 'default') + ' navbar-btn kb-nav-btn" role="button" href="' + cfg.url + '" ' + target + '>' +
+                     '  <div class="fa fa-' + cfg.icon + '" style="' + iconStyle + '"></div>' + label + '</a>');
 
                } else {
-                  var button = $('<button data-button="' + cfg.name + '" id="kb-' + cfg.name + '-btn" class="btn btn-' + (cfg.style || 'default') + ' navbar-btn kb-nav-btn">' +
+                  button = $('<button data-button="' + cfg.name + '" id="kb-' + cfg.name + '-btn" class="btn btn-' + (cfg.style || 'default') + ' navbar-btn kb-nav-btn">' +
                         '  <div class="fa fa-' + cfg.icon + '" style="' + iconStyle + '"></div>' + label + '</button>')
                      .on('click', function (e) {
                         e.preventDefault();
@@ -155,39 +159,39 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
                      '  <div class="fa fa-' + cfg.icon + '" style="' + iconStyle + '"></div>' + label + '</button>');
                if (cfg.disabled) {
                   button.prop('disabled', true);
-               } 
+               }
 
                var menu = $('<ul class="dropdown-menu" role="menu"></ul>');
                if (cfg.items) {
-               for (var i = 0; i < cfg.items.length; i++) {
-                  var item = cfg.items[i];
-                  if (item.type === 'divider') {
-                     menu.append('<li class="divider"></li>');
-                  } else {
-                     var menuItem = $('<li></li>');
+                  for (var i = 0; i < cfg.items.length; i++) {
+                     var item = cfg.items[i];
+                     if (item.type === 'divider') {
+                        menu.append('<li class="divider"></li>');
+                     } else {
+                        var menuItem = $('<li></li>');
 
-                     if (item.url) {
-                        var link = $('<a></a>')
-                           .attr('href', item.url)
-                           .attr('data-menu-item', item.name);
-                     } else if (item.callback) {
-                        var link = $('<a></a>')
-                           .attr('href', '#')
-                           .attr('data-menu-item', item.name)
-                           .on('click', item.callback);
-                     }
-                     if (item.external) {
-                        link.attr('target', '_blank');
-                     }
+                        if (item.url) {
+                           var link = $('<a></a>')
+                              .attr('href', item.url)
+                              .attr('data-menu-item', item.name);
+                        } else if (item.callback) {
+                           var link = $('<a></a>')
+                              .attr('href', '#')
+                              .attr('data-menu-item', item.name)
+                              .on('click', item.callback);
+                        }
+                        if (item.external) {
+                           link.attr('target', '_blank');
+                        }
 
-                     var icon = $('<div class="navbar-icon" style=""></div>');
-                     if (item.icon) {
-                        icon.append($('<span class="fa fa-' + item.icon + '"  class="navbar-icon"></span>'));
-                     }
+                        var icon = $('<div class="navbar-icon" style=""></div>');
+                        if (item.icon) {
+                           icon.append($('<span class="fa fa-' + item.icon + '"  class="navbar-icon"></span>'));
+                        }
 
-                     menu.append(menuItem.append(link.append(icon).append(item.label)));
+                        menu.append(menuItem.append(link.append(icon).append(item.label)));
+                     }
                   }
-               }
                }
                var dropdown = $('<div class="dropdown" style="display: inline-block;"></div>').append(button).append(menu);
                if (cfg.place === 'end') {
@@ -209,6 +213,7 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
          addDefaultMenu: {
             value: function (cfg) {
                cfg = cfg || {};
+               var hasRegularMenuItems = false;
                if (cfg.search !== false) {
                   this.addMenuItem({
                      name: 'search',
@@ -217,6 +222,7 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
                      url: '#/search/?q=*',
                      place: 'end'
                   });
+                  hasRegularMenuItems = true;
                }
                if (cfg.narrative !== false) {
                   this.addMenuItem({
@@ -227,6 +233,8 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
                      external: true,
                      place: 'end'
                   });
+                  hasRegularMenuItems = true;
+
                }
                if (cfg.dashboard !== false) {
                   this.addMenuItem({
@@ -236,12 +244,16 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
                      url: '#/dashboard',
                      place: 'end'
                   });
+                  hasRegularMenuItems = true;
+
                }
-               this.addMenuItem({
-                  type: 'divider',
-                  name: 'help',
-                  place: 'end'
-               });
+               if (hasRegularMenuItems) {
+                  this.addMenuItem({
+                     type: 'divider',
+                     name: 'help',
+                     place: 'end'
+                  });
+               }
 
                this.addHelpMenuItem({
                   name: 'contactus',
@@ -320,15 +332,17 @@ define(['jquery', 'nunjucks', 'kb.session', 'kb.config'],
             value: function (cfg) {
                var item = this.makeMenuItem(cfg);
                if (item) {
-                  if (cfg.place === 'end') {
-                     var menu = this.container.find('.navbar-menu .dropdown-menu');
-                     if (menu) {
+                  var menu = this.container.find('.navbar-menu .dropdown-menu');
+                  if (menu) {
+                     if (cfg.place === 'end') {
                         menu.append(item);
-                     }
-                  } else {
-                     var helpDivider = this.container.find('.navbar-menu .dropdown-menu [data-menu-item="help"]');
-                     if (helpDivider) {
-                        helpDivider.after(item);
+                     } else {
+                        var helpDivider = menu.find('[data-menu-item="help"]');
+                        if (helpDivider.length === 1) {
+                           helpDivider.after(item);
+                        } else {
+                           menu.prepend(item);
+                        }
                      }
                   }
                }

--- a/src/widgets/narrativemanager/NarrativeManager-welcome-cell-content.txt
+++ b/src/widgets/narrativemanager/NarrativeManager-welcome-cell-content.txt
@@ -1,0 +1,58 @@
+![KBase Logo](<%= docBaseUrl %>/wp-content/uploads/2014/11/kbase-logo-web.png)
+Welcome to the Narrative Interface!
+===
+
+What's a Narrative?
+---
+
+Design and carry out collaborative computational experiments while  
+creating Narratives: interactive, shareable, and reproducible records 
+of your data, computational steps, and thought processes.
+
+<a href="<%= docBaseUrl %>/narrative-guide">learn more...</a>
+
+
+Get Some Data
+---
+
+Click the Add Data button in the Data Panel to browse for KBase data or 
+upload your own. Mouse over a data object to add it to your Narrative, and  
+check out more details once the data appears in your list.
+
+<a href="<%= docBaseUrl %>/narrative-guide/explore-data">learn more...</a>
+
+
+Analyze It
+---
+
+Browse available analyses that can be run using KBase apps or methods 
+(apps are just multi-step methods that make some common analyses more 
+convenient). Select an analysis, fill in the fields, and click Run. 
+Output will be generated, and new data objects will be created and added 
+to your data list. Add to your results by running follow-on apps or methods.
+
+<a href="<%= docBaseUrl %>/narrative-guide/browse-apps-and-methods">learn more...</a>
+
+
+Save and Share Your Narrative
+---
+
+Be sure to save your Narrative frequently. When you're ready, click  
+the share button above to let collaborators view your analysis steps 
+and results. Or better yet, make your Narrative public and help expand 
+the social web that KBase is building to make systems biology research 
+open, collaborative, and more effective.
+
+<a href="<%= docBaseUrl %>/narrative-guide/share-narratives/">learn more...</a>
+
+Find Documentation and Help
+---
+
+For more information, please see the 
+<a href="<%= docBaseUrl %>/narrative-guide">Narrative Interface User Guide</a> 
+or the <a href="<%= docBaseUrl %>/tutorials">app/method tutorials</a>.
+
+Questions? <a href="<%= docBaseUrl %>/contact-us">Contact us</a>!
+
+Ready to begin adding to your Narrative? You can keep this Welcome cell or 
+delete it with the trash icon in the top right corner.

--- a/src/widgets/narrativemanager/NarrativeManager.js
+++ b/src/widgets/narrativemanager/NarrativeManager.js
@@ -593,73 +593,85 @@ var NarrativeManager = function(options, auth, auth_cb) {
     this.KB_CODE_CELL= 'kb_code';
     this.KB_STATE= 'widget_state';
     
-    
-    
-    // this.introText =
-    //     "Welcome to KBase!\n============\n\n"+
-    //     "Add Data to this Narrative\n------------\n\n"+
-    //     "Click on 'Get Data' and browse for KBase data or upload your own."+
-    //     "Select the data and click 'Add to narrative'.  Perhaps start by "+
-    //     "importing your favorite Genome.  Once your data has been loaded, "+
-    //     "you can inspect it in the data list.\n<br>\n\n"+
-    //     "Perform an Analysis\n------------\n\n"+
-    //     "When you're ready, select an App or Method to run on your data.  "+
-    //     "Simply click on an App or Method on the side bar, and it will appear "+
-    //     "directly in your Narrative.  Fill in the parameters and click run.  "+
-    //     "Output will be generated and new data objects may be created and added "+
-    //     "to your data list.  Add and run as many Apps and Methods as you like!\n\n"+
-    //     "Long running computations can be tracked in your Jobs panel, located on "+
-    //     "the side panel under the 'Manage' tab.\n<br>\n\n"+
-    //     "Save & Share your Results\n------------\n\n"+
-    //     "When you're ready, name this Narrative and save it.  Once it is saved, "+
-    //     "click on the 'share' button above to let others view your analysis.  Or if you're "+
-    //     "brave, make it public for the world to see.\n<br><br>\n\n"+
-    //     "\nThat's it!\n\n"+
-    //     "<b>Questions?</b> Visit https://kbase.us to search for more detailed tutorials and documentation.\n\n"+
-    //     "<b>More Questions?</b> Email: [help@kbase.us](mailto:help@kbase.us)\n\n\n";
-    this.docBaseUrl = kb.urls ? kb.urls.docsite.baseUrl : "http://staging.kbase.us";
-    this.introText = 
-        "![KBase Logo](" + this.docBaseUrl + "/wp-content/uploads/2014/11/kbase-logo-web.png)\n" +
-        "Welcome to the Narrative Interface!\n" +
-        "===\n\n" + 
-        "<a href='" + this.docBaseUrl + "/narrative-guide/' style='text-decoration:underline'>What's a Narrative?</a>\n" +
-        "---\n" +
-        "Design and carry out collaborative computational experiments while " + 
-        "creating Narratives: interactive, shareable, and reproducible records " +
-        "of your data, computational steps, and thought processes.\n\n" +
-        "<a href='" + this.docBaseUrl + "/narrative-guide/explore-data/' style='text-decoration:underline'>Get Some Data</a>\n" +
-        "---\n" +
-        "Click the Add Data button in the Data Panel to browse for KBase data or " +
-        "upload your own. Mouse over a data object to add it to your Narrative, and " + 
-        "check out more details once the data appears in your list.\n\n" +
-        "<a href='" + this.docBaseUrl + "/narrative-guide/browse-apps-and-methods/' style='text-decoration:underline'>Analyze It</a>\n" + 
-        "---\n" +
-        "Browse available analyses that can be run using KBase apps or methods " +
-        "(apps are just multi-step methods that make some common analyses more " +
-        "convenient). Select an analysis, fill in the fields, and click Run. " +
-        "Output will be generated, and new data objects will be created and added " +
-        "to your data list. Add to your results by running follow-on apps or methods.\n\n" +
-        "<a href='" + this.docBaseUrl + "/narrative-guide/share-narratives/' style='text-decoration:underline'>Save and Share Your Narrative</a>\n" +
-        "---\n" +
-        "Be sure to save your Narrative frequently. When you&apos;re ready, click " + 
-        "the share button above to let collaborators view your analysis steps " +
-        "and results. Or better yet, make your Narrative public and help expand " +
-        "the social web that KBase is building to make systems biology research " +
-        "open, collaborative, and more effective.\n\n" +
-        "<a href='" + this.docBaseUrl + "/narrative-guide/' style='text-decoration:underline'>Find Documentation and Help</a>\n" +
-        "---\n" +
-        "For more information, please see the " +
-        "<a href='" + this.docBaseUrl + "/narrative-guide/' style='text-decoration:underline'>Narrative Interface User Guide</a> " +
-        "or the <a href='" + this.docBaseUrl + "/apps/' style='text-decoration:underline'>app/method tutorials</a>.\n\n" +
-        "Questions? <a href='" + this.docBaseUrl + "/contact-us' style='text-decoration:underline'>Contact us</a>!\n\n" +
-        "Ready to begin adding to your Narrative? You can keep this Welcome cell or " +
-        "delete it with the trash icon in the top right corner.";
+    /*
+        Note: The source for the template is: NarrativeManager-welcome-cell-content.txt
+        Do not change the content here!
+        
+        See NarrativeManager-welcome-cell-content.txt and /tools/markdown-to-js-string.pl
+        E.g.
+        
+        ../../../tools/markdown-to-js-string.pl < NarrativeManager-welcome-cell-content.txt
+    */
+    var introTemplate = (function () {
+        var s = '';
+        s += '![KBase Logo](<%= docBaseUrl %>/wp-content/uploads/2014/11/kbase-logo-web.png)\n';
+        s += 'Welcome to the Narrative Interface!\n';
+        s += '===\n';
+        s += '\n';
+        s += 'What\'s a Narrative?\n';
+        s += '---\n';
+        s += '\n';
+        s += 'Design and carry out collaborative computational experiments while  \n';
+        s += 'creating Narratives: interactive, shareable, and reproducible records \n';
+        s += 'of your data, computational steps, and thought processes.\n';
+        s += '\n';
+        s += '<a href="<%= docBaseUrl %>/narrative-guide">learn more...</a>\n';
+        s += '\n';
+        s += '\n';
+        s += 'Get Some Data\n';
+        s += '---\n';
+        s += '\n';
+        s += 'Click the Add Data button in the Data Panel to browse for KBase data or \n';
+        s += 'upload your own. Mouse over a data object to add it to your Narrative, and  \n';
+        s += 'check out more details once the data appears in your list.\n';
+        s += '\n';
+        s += '<a href="<%= docBaseUrl %>/narrative-guide/explore-data">learn more...</a>\n';
+        s += '\n';
+        s += '\n';
+        s += 'Analyze It\n';
+        s += '---\n';
+        s += '\n';
+        s += 'Browse available analyses that can be run using KBase apps or methods \n';
+        s += '(apps are just multi-step methods that make some common analyses more \n';
+        s += 'convenient). Select an analysis, fill in the fields, and click Run. \n';
+        s += 'Output will be generated, and new data objects will be created and added \n';
+        s += 'to your data list. Add to your results by running follow-on apps or methods.\n';
+        s += '\n';
+        s += '<a href="<%= docBaseUrl %>/narrative-guide/browse-apps-and-methods">learn more...</a>\n';
+        s += '\n';
+        s += '\n';
+        s += 'Save and Share Your Narrative\n';
+        s += '---\n';
+        s += '\n';
+        s += 'Be sure to save your Narrative frequently. When you\'re ready, click  \n';
+        s += 'the share button above to let collaborators view your analysis steps \n';
+        s += 'and results. Or better yet, make your Narrative public and help expand \n';
+        s += 'the social web that KBase is building to make systems biology research \n';
+        s += 'open, collaborative, and more effective.\n';
+        s += '\n';
+        s += '<a href="<%= docBaseUrl %>/narrative-guide/share-narratives/">learn more...</a>\n';
+        s += '\n';
+        s += 'Find Documentation and Help\n';
+        s += '---\n';
+        s += '\n';
+        s += 'For more information, please see the \n';
+        s += '<a href="<%= docBaseUrl %>/narrative-guide">Narrative Interface User Guide</a> \n';
+        s += 'or the <a href="<%= docBaseUrl %>/tutorials">app/method tutorials</a>.\n';
+        s += '\n';
+        s += 'Questions? <a href="<%= docBaseUrl %>/contact-us">Contact us</a>!\n';
+        s += '\n';
+        s += 'Ready to begin adding to your Narrative? You can keep this Welcome cell or \n';
+        s += 'delete it with the trash icon in the top right corner.';
+        return s;
+    }());
+
+    // Do we really need a guard here? If there is no kb.urls, the deploy is pretty broken...
+    var docBaseUrl = kb.urls ? kb.urls.docsite.baseUrl : "http://staging.kbase.us";
+    this.introText = _.template(introTemplate)({docBaseUrl: docBaseUrl});
+
 };
 
-
-
 /*
-
 WORKSPACE INFO
 0: ws_id id
 1: ws_name workspace
@@ -670,10 +682,4 @@ WORKSPACE INFO
 6: permission globalread,
 7: lock_status lockstat
 8: usermeta metadata
-
 */
- 
- 
- 
-
-

--- a/tools/markdown-to-js-string.pl
+++ b/tools/markdown-to-js-string.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+# Markdown to concatenated javascript string.
+
+print "\var markdownString = (function () {\n";
+print "    var s = '';\n";
+foreach $line (<STDIN>) {
+    # all single quotes are escaped
+    $line =~ s/\'/\\'/g;
+    # all newlines become \n
+    $line =~ s/\n/\\n/g;
+    # wrap all  lines in 
+    print "\    s += '" . $line . "';\n";
+}
+print "    return s;\n";
+print "}());\n";

--- a/tools/markdown-to-js-string.pl
+++ b/tools/markdown-to-js-string.pl
@@ -9,7 +9,7 @@ foreach $line (<STDIN>) {
     $line =~ s/\'/\\'/g;
     # all newlines become \n
     $line =~ s/\n/\\n/g;
-    # wrap all  lines in 
+
     print "\    s += '" . $line . "';\n";
 }
 print "    return s;\n";


### PR DESCRIPTION
The content for the welcome cell is now stored in a plain text file in normal markdown
format. Well, one difference is that there is an underscore template variable placeholder
for inserting the runtime doc site base url. This is available from the site config in
the javascript and is inserted into the content via underscore templates.
The markdown is converted to a snipped of javasript, which encodes the text as a concatenated
string (or rather a sequence of concatenations), which is encapsulated in an anonymous
function. The perl script (markdown-to-js-string.pl) is run with the text file as stdin,
and outputs the javscript, which can just be copied and pasted into the javscript file.
Also, the central config file needed updating to reflect the producton base url for the
doc site.