### PR TITLE
Hotfix for JIRA #1884 - fix staging links

### DIFF
--- a/functional-site/config.json
+++ b/functional-site/config.json
@@ -29,8 +29,8 @@
          }
       },
       "docsite": {
-         "baseUrl": "http://staging.kbase.us",
-         "host": "staging.kbase.us",
+         "baseUrl": "http://kbase.us",
+         "host": "kbase.us",
          "paths": {
             "about": "/what-is-kbase",
             "contact": "/contact-us",

--- a/functional-site/index.html
+++ b/functional-site/index.html
@@ -93,7 +93,7 @@
       /* TODO: This check needst to be before any javascript. We have to assume ANY library
          loaded will depend on the conditions set checkBrowser  */
       function checkBrowser() {
-         var redirectUrl = '//staging.kbase.us/supported-browsers';
+         var redirectUrl = '//kbase.us/supported-browsers';
 
          if (bowser.msie && bowser.version <= 9) {
             var protocol = window.location.protocol;
@@ -517,15 +517,15 @@
                         <!--
                                     <li><a target="_blank" href="http://kbase.us/services/docs/uploader/uploader.html">Upload</a></li>-->
                         <li role="presentation" class="divider"></li>
-                        <li><a target="_blank" href="https://staging.kbase.us/about">About</a>
+                        <li><a target="_blank" href="https://kbase.us/about">About</a>
                         </li>
-                        <li><a target="_blank" href="https://staging.kbase.us/narrative-guide">Narrative Tutorial</a>
+                        <li><a target="_blank" href="https://kbase.us/narrative-guide">Narrative Tutorial</a>
                         </li>
-                        <li><a target="_blank" href="https://staging.kbase.us/contact-us">Contact Us</a>
+                        <li><a target="_blank" href="https://kbase.us/contact-us">Contact Us</a>
                         </li>
                      </ul>
                   </div>
-                  <a href="http://staging.kbase.us">
+                  <a href="http://kbase.us">
                      <img id="logo" src="assets/navbar/images/kbase_logo.png" width="46">
                   </a>
                </div>

--- a/src/widgets/LoginWidget/templates/loggedout.html
+++ b/src/widgets/LoginWidget/templates/loggedout.html
@@ -6,7 +6,7 @@
 	<ul class="dropdown-menu" role="menu">
 		<li><a href="#" data-menu-item="signin"><div style="display:inline-block; width: 34px;"><span class="fa fa-sign-in" style="font-size: 150%; "></span></div>Sign in to KBase</a></li>
 		<li class="divider"></li>
-		<li><a href="http://staging.kbase.us/new-to-kbase" data-menu-item="signup"><div style="display:inline-block; width: 34px;"><span class="fa fa-pencil" style="font-size: 150%; "></span></div> Signup</a></ll>
+		<li><a href="http://kbase.us/new-to-kbase" data-menu-item="signup"><div style="display:inline-block; width: 34px;"><span class="fa fa-pencil" style="font-size: 150%; "></span></div> Signup</a></ll>
 
 		<li><a href="#" data-menu-item="logout"><div style="display:inline-block; width: 34px;"><span class="fa fa-question" style="font-size: 150%; margin-right: 10px;"></span></div> Lost Password?</a></ll>
 	</ul>

--- a/src/widgets/narrativemanager/NarrativeManager.js
+++ b/src/widgets/narrativemanager/NarrativeManager.js
@@ -617,7 +617,7 @@ var NarrativeManager = function(options, auth, auth_cb) {
     //     "\nThat's it!\n\n"+
     //     "<b>Questions?</b> Visit https://kbase.us to search for more detailed tutorials and documentation.\n\n"+
     //     "<b>More Questions?</b> Email: [help@kbase.us](mailto:help@kbase.us)\n\n\n";
-    this.docBaseUrl = kb.urls ? kb.urls.docsite.baseUrl : "http://staging.kbase.us";
+    this.docBaseUrl = kb.urls ? kb.urls.docsite.baseUrl : "http://kbase.us";
     this.introText = 
         "![KBase Logo](" + this.docBaseUrl + "/wp-content/uploads/2014/11/kbase-logo-web.png)\n" +
         "Welcome to the Narrative Interface!\n" +


### PR DESCRIPTION
Repairs links to kbase.us which were inadvertently left as staging.kbase.us. During and since launch (except for the past week, but reinstated today), staging.kbase.us was redirected to kbase.us to accommodate these incorrect links. (They were left in place originally due to code freeze, and worked around with the redirect; in the intervening months they have been piecemeal fixed in development, but those changes have not made their way into production. This focuses on getting just these small fixes in place.)