### PR TITLE
Restore jquery-ui js and css to un-break the data type viewers.

### DIFF
--- a/functional-site/index.html
+++ b/functional-site/index.html
@@ -8,7 +8,7 @@
    <!-- external css -->
    <link rel="stylesheet" type="text/css" href="/ext/bootstrap/3.3.2/css/bootstrap.min.css" />
    <!-- jquery-ui-1.10.0.custom.css is needed for the landing page card layout, some old landing pages still use this style -->
-   <!--<link rel="stylesheet" type="text/css" href="/ext/jquery-ui/1.10.3/css/custom-theme/jquery-ui-1.10.0.custom.css">-->
+   <link rel="stylesheet" type="text/css" href="/ext/jquery-ui/1.10.3/css/custom-theme/jquery-ui-1.10.0.custom.css">
 
    <!-- DataTable 1.10.4 css dependencies. 2014-01-29 eap -->
    <!-- <link rel="stylesheet" type="text/css" href="assets/css/dataTables.bootstrap.css" /> -->
@@ -109,7 +109,7 @@
 
    <script src="/ext/jquery/jquery-1.10.2.min.js"></script>
    <!-- <script src="../ext/jquery-migrate/jquery-migrate-1.2.1.js"></script> -->
-  <!-- <script src="/ext/jquery-ui/1.10.3/js/jquery-ui-1.10.3.custom.min.js"></script>-->
+   <script src="/ext/jquery-ui/1.10.3/js/jquery-ui-1.10.3.custom.min.js"></script>
    <script src="/ext/blockUI/jquery.blockUI.js"></script>
    <script src="/ext/bootstrap/3.3.2/js/bootstrap.js"></script>
    <script src="/ext/d3/d3.v3.min.js"></script>


### PR DESCRIPTION
This may cause issues with bootstrap -- the reason jquery ui was disabled was to resolve an incompatibility with bootstrap. We should keep an eye on this in ci and next testing.