### PR TITLE
Fix KBASE-1774: login form help link should point to new-to-kbase page

### DIFF
--- a/functional-site/views/login.html
+++ b/functional-site/views/login.html
@@ -36,7 +36,7 @@
                      <div class="form-group" style="margin-top: 3em; margin-bottom: 0">
                         <a target="_blank" href="http://gologin.kbase.us/Signup" class="btn btn-block btn-link">New to KBase? Sign Up</a>
                         <a target="_blank" href="http://gologin.kbase.us/ResetPassword" class="btn btn-block btn-link">Forgot your password?</a>
-                        <a target="_blank" href="http://kbase.us/login-help" class="btn btn-block btn-link">Help</a>
+                        <a target="_blank" href="http://kbase.us/new-to-kbase" class="btn btn-block btn-link">Help</a>
                      </div>
                   </div>
                </div>


### PR DESCRIPTION
Change login form's help link to point to the doc site's new-to-kbase page. It was previously set to a sign up help page which needs a bit more work to be production worthy, and it is better to get this link working now than to hold it up until the help page is ready.
See KBASE-1774