### PR TITLE
Added path config for FBA widgets

### DIFF
--- a/widget-paths.js
+++ b/widget-paths.js
@@ -38,7 +38,7 @@ define([], function() {
             'KBasePhenotypes.PhenotypeSimulationSet' : {
                 'deps' : ['KBModeling']
             },
-            'KBaseSearch.GenomeSet' {
+            'KBaseSearch.GenomeSet' : {
                 'deps' : ['KBModeling']
             },
             'kbaseTabTable' : {

--- a/widget-paths.js
+++ b/widget-paths.js
@@ -1,0 +1,82 @@
+define([], function() {
+    return {
+        'paths': {
+            'kbaseTabTable'                         : 'src/widgets/modeling/kbaseTabTable',
+            'KBModeling'                            : 'src/widgets/modeling/KBModeling',
+            'KBaseFBA.FBAModel'                     : 'src/widgets/modeling/KBaseFBA.FBAModel',
+            'KBaseFBA.FBAModelSet'                  : 'src/widgets/modeling/KBaseFBA.FBAModelSet',
+            'KBaseFBA.FBA'                          : 'src/widgets/modeling/KBaseFBA.FBA',
+            'KBaseFBA.FBAComparison'                : 'src/widgets/modeling/KBaseFBA.FBAComparison',        
+            'KBaseBiochem.Media'                    : 'src/widgets/modeling/KBaseBiochem.Media',
+            'KBasePhenotypes.PhenotypeSet'          : 'src/widgets/modeling/KBasePhenotypes.PhenotypeSet',
+            'KBasePhenotypes.PhenotypeSimulationSet': 'src/widgets/modeling/KBasePhenotypes.PhenotypeSimulationSet',
+            'KBaseSearch.GenomeSet'                 : 'src/widgets/modeling/KBaseSearch.GenomeSet',
+            'kbaseTabTableTabs'                     : 'src/widgets/modeling/kbaseTabs',
+            'modelSeedVizConfig'                    : 'src/widgets/modeling/modelSeedVizConfig',
+            'msPathway'                             : 'src/widgets/modeling/msPathway',
+            'kbasePathways'                         : 'src/widgets/modeling/kbasePathways',
+        },
+        'shim': {
+            'KBaseFBA.FBAModel' : {
+                'deps' : ['KBModeling']
+            },
+            'KBaseFBA.FBAModelSet' : {
+                'deps' : ['KBModeling']
+            },
+            'KBaseFBA.FBA' : {
+                'deps' : ['KBModeling']
+            },
+            'KBaseFBA.FBAComparison' : {
+                'deps' : ['KBModeling']
+            },
+            'KBaseBiochem.Media' : {
+                'deps' : ['KBModeling']
+            },
+            'KBasePhenotypes.PhenotypeSet' : {
+                'deps' : ['KBModeling']
+            },
+            'KBasePhenotypes.PhenotypeSimulationSet' : {
+                'deps' : ['KBModeling']
+            },
+            'KBaseSearch.GenomeSet' {
+                'deps' : ['KBModeling']
+            },
+            'kbaseTabTable' : {
+                'deps' : ['jquery', 
+                          'jquery-dataTables',
+                          'jquery-dataTables-bootstrap',
+                          'bootstrap',
+                          'KBModeling',
+                          'KBaseFBA.FBAModel',
+                          'KBaseFBA.FBAModelSet',
+                          'KBaseFBA.FBA',
+                          'KBaseFBA.FBAComparison',
+                          'KBaseBiochem.Media',
+                          'KBasePhenotypes.PhenotypeSet',
+                          'KBasePhenotypes.PhenotypeSimulationSet',
+                          'KBaseFBA.FBAComparison',
+                          'kbaseTabTableTabs']
+            },
+            'kbasePathways' : {
+                'deps' : ['jquery', 
+                          'kbwidget', 
+                          'KBModeling', 
+                          'jquery-dataTables',
+                          'jquery-dataTables-bootstrap',
+                          'bootstrap',
+                          'msPathway']
+            },
+            'msPathway' : {
+                'deps' : ['jquery',
+                          'modelSeedVizConfig',
+                          'd3']
+            },
+            'kbaseTabTableTabs' : {
+                'deps' : ['jquery',
+                          'jquery-dataTables',
+                          'jquery-dataTables-bootstrap',
+                          'bootstrap']
+            }
+        }
+    };
+});

--- a/widget-paths.js
+++ b/widget-paths.js
@@ -18,13 +18,16 @@ define([], function() {
         },
         'shim': {
             'KBaseFBA.FBAModel' : {
-                'deps' : ['KBModeling']
+                'deps' : ['KBModeling',
+                          'kbasePathways']
             },
             'KBaseFBA.FBAModelSet' : {
-                'deps' : ['KBModeling']
+                'deps' : ['KBModeling',
+                          'kbasePathways']
             },
             'KBaseFBA.FBA' : {
-                'deps' : ['KBModeling']
+                'deps' : ['KBModeling',
+                          'kbasePathways']
             },
             'KBaseFBA.FBAComparison' : {
                 'deps' : ['KBModeling']


### PR DESCRIPTION
This adds a mini version of what will become the widget path configuration file. It still needs to be reconciled with namespacing and such that's going on in the ease-dev-campaign branch, which in turn will need some updates in the Narrative.

This is put here to hopefully ease the way in the short term (pre-RSV) for linking the Narrative to use the FBA widgets that are currently only in ui-common.

There will be a parallel PR in the narrative repo shortly...