### PR TITLE
Allow generic visualizer widget to render when auth token is not present.

### DIFF
--- a/src/widgets/dataview/OverviewWidget.js
+++ b/src/widgets/dataview/OverviewWidget.js
@@ -124,64 +124,66 @@ define(['kb.widget.dataview.base', 'kb.utils.api', 'kb.utils', 'kb.session', 'kb
 
                   Navbar
                   .clearButtons();
+              
+                  if (Session.isLoggedIn()) {
+                    Navbar.addDropdown({
+                            place: 'end',
+                            name: 'download',
+                            style: 'default',
+                            icon: 'download',
+                            label: 'Download',
+                            widget: 'kbaseDownloadPanel',
+                            params: {'ws': this.getState('workspace.id'), 'obj': this.getState('object.id'), 'ver': this.getState('object.version')}
+                    });
 
-                  Navbar.addDropdown({
-                	  place: 'end',
-                	  name: 'download',
-                	  style: 'default',
-                	  icon: 'download',
-                	  label: 'Download',
-                	  widget: 'kbaseDownloadPanel',
-                	  params: {'ws': this.getState('workspace.id'), 'obj': this.getState('object.id'), 'ver': this.getState('object.version')}
-                  });
+                    Navbar
+                    .addButton({
+                          name: 'copy',
+                          label: '+ New Narrative',
+                          style: 'primary',
+                          icon: 'plus-square',
+                          url: '/functional-site/#/narrativemanager/new?copydata=' + dataRef,
+                          external: true
+                       })
+                       /*.addButton({
+                          name: 'download',
+                          label: 'Download',
+                          style: 'primary',
+                          icon: 'download',
+                          callback: function () {
+                             alert('download object');
+                          }.bind(this)
+                       })*/;
 
-                  Navbar
-                  .addButton({
-                        name: 'copy',
-                        label: '+ New Narrative',
-                        style: 'primary',
-                        icon: 'plus-square',
-                        url: '/functional-site/#/narrativemanager/new?copydata=' + dataRef,
-                        external: true
-                     })
-                     /*.addButton({
-                        name: 'download',
-                        label: 'Download',
-                        style: 'primary',
-                        icon: 'download',
-                        callback: function () {
-                           alert('download object');
-                        }.bind(this)
-                     })*/;
-
-                  var narratives = this.getState('writableNarratives');
-                  if (narratives) {
-                     var items = [];
-                     for (var i = 0; i < narratives.length; i++) {
-                        var narrative = narratives[i];
-                        items.push({
-                           name: 'narrative_' + i,
-                           icon: 'file',
-                           label: narrative.metadata.narrative_nice_name,
-                           external: true,
-                           callback: (function (narrative) {
-                              var widget = this;
-                              return function (e) {
-                                 e.preventDefault();
-                                 widget.copyObjectToNarrative(narrative);
-                              }
-                           }.bind(this))(narrative)
-                        });
-                     }
-                     Navbar.addDropdown({
-                        place: 'end',
-                        name: 'options',
-                        style: 'default',
-                        icon: 'copy',
-                        label: 'Copy',
-                        items: items
-                     });
-                  }
+                    var narratives = this.getState('writableNarratives');
+                    if (narratives) {
+                       var items = [];
+                       for (var i = 0; i < narratives.length; i++) {
+                          var narrative = narratives[i];
+                          items.push({
+                             name: 'narrative_' + i,
+                             icon: 'file',
+                             label: narrative.metadata.narrative_nice_name,
+                             external: true,
+                             callback: (function (narrative) {
+                                var widget = this;
+                                return function (e) {
+                                   e.preventDefault();
+                                   widget.copyObjectToNarrative(narrative);
+                                }
+                             }.bind(this))(narrative)
+                          });
+                       }
+                       Navbar.addDropdown({
+                          place: 'end',
+                          name: 'options',
+                          style: 'default',
+                          icon: 'copy',
+                          label: 'Copy',
+                          items: items
+                       });
+                    }
+                }
                   break;
                case 'notfound':
                   Navbar

--- a/src/widgets/dataview/kbaseDataViewGenericViz.js
+++ b/src/widgets/dataview/kbaseDataViewGenericViz.js
@@ -47,23 +47,21 @@
 	    
             this.$mainPanel = $("<div>");
             this.$elem.append(this.$mainPanel);
-	    
             if (!this.auth.token) {
-                this.ws = kb.ws;  //new Workspace(this.options.ws_url);
+                this.ws = new Workspace(this.options.ws_url);
                 this.loggedIn = false;
             } else {
-                //console.log(['authenticated:', this.auth]);
                 this.ws = new Workspace(this.options.ws_url, this.auth);
                 this.loggedIn = true;
-                this.getInfoAndRender();
             }
+            this.getInfoAndRender();
 	    
             return this;
         },
 
         loggedInCallback: function(event, auth) {
             this.options.auth = auth;
-            //console.log(['authenticated:', this.options.auth]);
+            // console.log(['authenticated:', this.options.auth]);
             this.ws = new Workspace(this.options.ws_url, this.options.auth);
             this.loggedIn = true;
             this.getInfoAndRender();


### PR DESCRIPTION
Also, inhibit buttons when no auth token present since they don't do anything useful.