### PR TITLE
Correct GC content display for genome landing pages

### DIFF
--- a/src/widgets/genomes/kbaseGenomeOverview.js
+++ b/src/widgets/genomes/kbaseGenomeOverview.js
@@ -305,8 +305,9 @@
                         if (dnaLength)
                             gcContent = (gcContent/dnaLength*100).toFixed(2) + " %";
                     }
-                    else
-                        gcContent = Number(gcContent * 100).toFixed(2) + " %";
+                    else {
+                        gcContent = gcContent.toFixed(2) + " %";
+                    }
                 }
             } else if (Number(genome.gc_content) < 1.0) {
                 gcContent = Number(genome.gc_content * 100).toFixed(2) + " %";


### PR DESCRIPTION
If the gc_content from the workspace object is already a float, do not compute a percentage.  This currently displays 100X the amount of GC actually in the reference genome objects.  This change will correct that issue.