### PR TITLE
Minor css change in generic Heatmap vis widget

### DIFF
--- a/src/widgets/vis/kbaseHeatmap.js
+++ b/src/widgets/vis/kbaseHeatmap.js
@@ -633,7 +633,7 @@ define('kbaseHeatmap',
             chart
                 .enter()
                     .append('rect')
-                    .attr('class', 'cell')
+                    .attr('class', 'davis-cell')
             ;
 
             chart


### PR DESCRIPTION
@thomasoniii - The class 'cell' is clashing with some CSS from iPython notebook and the narrative.  As far as I can tell, this class isn't actually being used anywhere by the heatmap widget, but so we can select it in the future I changed the name rather than removing the class altogether.

Tested locally in the Narrative, this seems to work.