### PR TITLE
KBASE-2634 hotfix

### DIFF
--- a/src/widgets/dashboard/CollaboratorsWidget/templates/authorized.html
+++ b/src/widgets/dashboard/CollaboratorsWidget/templates/authorized.html
@@ -1,4 +1,4 @@
-<div class="collapse" id="{{env.widgetName}}-more-info-{{env.instanceId}}">
+<div class="collapse" id="{{env.widgetName}}-more-info-{{env.generatedId}}">
    <div class="well">
       <p>This table shows your "Collaborators" - other KBase users who have access to Narratives to which you also have access.</p>
    </div>
@@ -12,7 +12,7 @@ You do not yet have any collaborators. To gain collaborators, you need to create
 
 {% else  %}
 
-<table class="table" id="collaborator_table_{{env.instanceId}}">
+<table class="table" id="collaborator_table_{{env.generatedId}}">
 	<thead>
 	<tr>
 		<th>Name</th>
@@ -35,7 +35,7 @@ You do not yet have any collaborators. To gain collaborators, you need to create
 
 <script>
 require(['jquery'], function ($) {
-	$('#collaborator_table_{{env.instanceId}}').DataTable({
+	$('#collaborator_table_{{env.generatedId}}').DataTable({
         initComplete: function (settings) {
             var api = this.api();
             var rowCount = api.data().length;

--- a/src/widgets/dashboard/DashboardWidget.js
+++ b/src/widgets/dashboard/DashboardWidget.js
@@ -403,18 +403,26 @@ define(['nunjucks', 'jquery', 'q', 'kb.session', 'kb.utils', 'kb.user_profile', 
             onHeartbeat: {
                 value: function (data) {
                     if (this.status === 'dirty') {
+                        // make sure the flag is reset syncronously.
+                        // If we reset the flag in refresh().then(), as we 
+                        // did at one time, there is race condition -- another
+                        // heartbeat may occur during the refresh handling and 
+                        // trigger a second refresh (since the widget is still 
+                        // dirty.)
+                        this.status = 'clean';
                         this.refresh()
                             .then(function () {
-                                this.status = 'clean';
+                                // anything
                             }.bind(this))
                             .catch(function (err) {
                                 this.setError(err);
                             }.bind(this))
                             .done();
                     } else if (this.status === 'error') {
+                        this.status = 'errorshown';
                         this.refresh()
                             .then(function () {
-                                this.status = 'errorshown';
+                                // anything to do?
                             }.bind(this))
                             .catch(function (err) {
                                 this.setError(err);


### PR DESCRIPTION
Should fix the bug see on CI in which the Collaborator widget issues a datable complaint. In a better world, datatables would not do a rude thing like issue an alert, a console error report would seem more appropriate. Still, it does prompt one to fix the problem.
And that problem seems to be due to a race condition with resetting the "dirty" flag on the widget. It was being reset after the new content was rendered, which left a small opening for another heartbeat event to trigger another render. Normally that would just be an inefficiency, and perhaps an annoying although probably imperceptible flash of content. In this case, since datatables does not like be called twice on the same node, it complains with an alert. Actually, the second render should have been a completely different node, but that was part of the race condition.
The reason the bug is present mostly CI and only on Chrome (but this has not been wholly confirmed) is perhaps that CI has small datasets, so async code is faster (and perhaps other latency related differences), and JS timers work different on different browsers. It just so happens that with Chrome on CI this bug was reproducible (not 100%, but often enough). 
Two pieces to the solution:
- set the status flag from dirty to clean in the synchronous part of the handler, before the content is rendered. (Perhaps a better solution is to have another "cleaning" state, but save that for another day...)
- use the env.generatedId rather than env.instanceId in the widget template. instanceId is set upon widget creation, generatedId is set whenever the context is set up for a template render. Thus generatedId is unique for each render, and even if there is a double-render, each render should produce an independent dom node, and dataTables should be happy.