### PR TITLE
Disable refresh if refreshInterval is false, and set it to false for Dashboard

### DIFF
--- a/src/widgets/dashboard/DashboardWidget.js
+++ b/src/widgets/dashboard/DashboardWidget.js
@@ -246,7 +246,7 @@ define(['nunjucks', 'jquery', 'q', 'kb.session', 'kb.utils', 'kb.user_profile', 
                     // refreshing more expensive data.
                     // this.refreshBeat = 0;
                     //
-                    this.refreshInterval = 60000;
+                    this.refreshInterval = false;
                     this.refreshLastTime = null;
 
 
@@ -385,19 +385,22 @@ define(['nunjucks', 'jquery', 'q', 'kb.session', 'kb.utils', 'kb.user_profile', 
             },
             handleHeartbeat: {
                 value: function (data) {
-                    var now = (new Date()).getTime();
-                    if (!this.refreshLastTime) {
-                        this.refreshLastTime = now;
-                    }
-                    if (now - this.refreshLastTime >= this.refreshInterval) {
-                        if (this.onRefreshbeat) {
-                            this.onRefreshbeat(data);
+                    if (this.refreshInterval !== false) {
+                        var now = (new Date()).getTime();
+                        if (!this.refreshLastTime) {
                             this.refreshLastTime = now;
+                        }
+                        if (now - this.refreshLastTime >= this.refreshInterval) {
+                            if (this.onRefreshbeat) {
+                                this.onRefreshbeat(data);
+                                this.refreshLastTime = now;
+                            }
                         }
                     }
                     if (this.onHeartbeat) {
                         this.onHeartbeat(data);
                     }
+                    
                 }
             },
             onHeartbeat: {


### PR DESCRIPTION
This is to address https://atlassian.kbase.us/browse/KBASE-2687, in which the dashboard goes wonky if the computer sleeps and the network connection is lost (yet the browser and javascript are still working.)
Not enough time to fix this before RSV so disabling refreshing will keep the dashboard out of trouble. However this needs to be addressed generally, and to cover more use cases. We DO need the UI to be refreshed periodically, in lieu of other mechanisms for passing changes in state from services to the ui, and we do need to gracefully handle network and service outages, slowdowns, and errors consistently and with recovery mechanisms (where applicable).