### PR TITLE
Hotfix so that SDK methods are viewable on man pages

### DIFF
--- a/functional-site/js/app.js
+++ b/functional-site/js/app.js
@@ -552,7 +552,11 @@ var app = angular.module('landing-pages',
 	.state('narrativestore',
 		{url: '/narrativestore/:type/:id',
 		templateUrl: 'views/narrative/narrative-store.html',
-		controller: 'NarrativeStore'});
+		controller: 'NarrativeStore'})
+  .state('narrativestore_namespace',
+    {url: '/narrativestore/:type/:namespace/:id',
+    templateUrl: 'views/narrative/narrative-store.html',
+    controller: 'NarrativeStore'});
                 
     $stateProvider
 	.state('kidledttype',

--- a/functional-site/js/directives/landingpages.js
+++ b/functional-site/js/directives/landingpages.js
@@ -1631,6 +1631,7 @@ angular.module('lp-directives')
             $(ele).append($panel);
             $panel.find('.panel-title').append('Narrative Apps and Methods Documentation');
             $panel.find('.panel-body').KBaseNarrativeStoreView({
+                    namespace:   scope.params.namespace,
                     type:   scope.params.type,
                     id:  scope.params.id,
                     loadingImage: "assets/img/ajax-loader.gif"

--- a/src/widgets/narrativemanager/kbaseNarrativeStoreView.js
+++ b/src/widgets/narrativemanager/kbaseNarrativeStoreView.js
@@ -4,10 +4,11 @@
         parent: "kbaseAuthenticatedWidget",
 
         options: {
+            namespace: null, // generally a module name
             type: null, // either app or method
             id: null,
             loadingImage: "assets/img/ajax-loader.gif",
-	    narrativeStoreUrl:"https://kbase.us/services/narrative_method_store"
+	    narrativeStoreUrl:"https://kbase.us/services/narrative_method_store/rpc"
         },
 
         $mainPanel: null,
@@ -28,8 +29,15 @@
             this.$narMethodStoreInfo = $("<div>").css({margin:'10px', padding:'10px'});
             this.$elem.append(this.$narMethodStoreInfo);
 
-            this.narstore = new NarrativeMethodStore(this.options.narrativeStoreUrl+"/rpc");
+            if(kb.urls.narrative_method_store_url) {
+                this.options.narrativeStoreUrl = kb.urls.narrative_method_store_url;
+            }
+            this.narstore = new NarrativeMethodStore(this.options.narrativeStoreUrl);
             this.getNarMethodStoreInfo();
+
+            if (this.options.namespace) {
+                this.options.id = this.options.namespace + '/' + this.options.id;
+            }
 
             if (options.type==='app') {
                 this.fetchAppInfoAndRender();
@@ -74,10 +82,10 @@
 
                         self.$narMethodStoreInfo.append(
                             $('<table>').css({border:'1px solid #bbb', margin:'10px', padding:'10px'})
-                                /*.append($('<tr>')
+                                .append($('<tr>')
                                             .append($('<th>').append('Method Store URL  '))
                                             .append($('<td>').append(self.options.narrativeStoreUrl)))
-                                .append($('<tr>')
+                                /*.append($('<tr>')
                                             .append($('<th>').append('Method Spec Repo  '))
                                             .append($('<td>').append(status.git_spec_url)))
                                 .append($('<tr>')


### PR DESCRIPTION
Temporary fix in routing that allows man pages to show SDK module methods