### PR TITLE
fba barchart hack

### DIFF
--- a/src/widgets/modeling/KBaseFBA.FBA.js
+++ b/src/widgets/modeling/KBaseFBA.FBA.js
@@ -242,17 +242,6 @@ function KBaseFBA_FBA(modeltabs) {
         }]
     },
     {
-        "name": "Bar charts",
-        "widget": "kbasePMIBarchart",
-        "getParams": function() {
-
-            return {
-                fba_workspace : self.workspace,
-                fba_object : self.objName
-            }
-
-        }
-    }, {
         "name": "Pathways",
         "widget": "kbasePathways",
         "getParams": function() {
@@ -302,6 +291,7 @@ function KBaseFBA_FBA(modeltabs) {
 
     this.formatObject = function () {
         this.usermeta.model = self.data.fbamodel_ref;
+
         this.usermeta.media = self.data.media_ref;
         this.usermeta.objective = self.data.objectiveValue;
         this.usermeta.minfluxes = self.data.fluxMinimization;
@@ -531,12 +521,40 @@ function KBaseFBA_FBA(modeltabs) {
         }
     };
 
-	this.setData = function (indata) { // this is a mess
+	this.setData = function (indata, tabs) { // this is a mess
+
         self.data = indata;
         var p = self.modeltabs.kbapi('ws', 'get_objects', [{ref: indata.fbamodel_ref}]).then(function(data){
             self.model = data[0].data;
+
+            //this is a godawful hack. When we setData, lookup the PlantModelTemplate, and if it's there, then add a barchart
+            //otherwise, do nothing. Assume we'll attempt this if we've been given tabs.
+            if (tabs != undefined) {
+                self.modeltabs.kbapi('ws', 'get_objects', [{ref : self.model.template_ref}]).then(function(data) {
+
+                    if (data[0].info[1] == 'PlantModelTemplate') {
+
+                        tabs.$elem.find('[data-id=Pathways]').hide();
+
+                        var $barchartElem = $.jqElem('div')
+                        $barchartElem.kbasePMIBarchart(
+                                    {
+                                        fba_workspace : self.workspace,
+                                        fba_object : self.objName
+                                    }
+                                )
+
+                            tabs.addTab({
+                                "name": "Bar charts",
+                                'content' : $barchartElem
+                            });
+                    }
+                });
+            }
+
 			var kbModeling = new KBModeling();  // this is a mess
 			self.model = new kbModeling["KBaseFBA_FBAModel"](self.modeltabs);
+
 			self.model.setMetadata(data[0].info);
 			self.model.setData(data[0].data);
  			self.formatObject();

--- a/src/widgets/modeling/kbaseTabTable.js
+++ b/src/widgets/modeling/kbaseTabTable.js
@@ -87,7 +87,7 @@ $.KBWidget({
 
         self.kbapi('ws', 'get_objects', [param])
           .done(function(data){
-              var setMethod = self.obj.setData(data[0].data);
+              var setMethod = self.obj.setData(data[0].data, tabs);
 
               // see if setData method returns promise or not
               if (setMethod && 'done' in setMethod) {


### PR DESCRIPTION
This is a godawful hack to pull out the pathways tab and put in a bar chart tab for plant related data.

It waits until the fba model object is loaded, then checks its template. If it's a plant, it'll add in the bar chart and toss the pathway.

It works...but there's a visual hiccup as the bar chart slides into place. Also, this takes place after the fba widget itself has loaded, which is probably less than ideal.

Nonetheless, it works.